### PR TITLE
Document BACKLOG.md workflow and session close procedures

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,18 @@
+# BACKLOG.md — MTG Deck Builder
+<!-- Capture scratch pad. Items live here until promoted to CLAUDE.md + GitHub issues. -->
+<!-- Cleared and bundled into the final session commit alongside CLAUDE.md, CHANGELOG.md, REVIEW.md. -->
+<!-- Last consolidated: 2026-03-07 -->
+
+- [ ] **bug** | Sideboard import/export parity with main board
+- [ ] **feature** | Move cards between boards or decks
+- [ ] **feature** | Search by artist
+- [ ] **feature** | Show art cards (display only, not addable)
+- [ ] **feature** | Custom deck arrangement by drag (see also #16)
+- [ ] **enhancement** | Sort by price
+- [ ] **chore** | Periodic codebase health check
+- [ ] **workflow** | Cross-platform session rule — one active machine per Claude Code session, git commit is the handoff
+- [ ] **workflow** | WIP mid-session pipeline — design full pipeline covering ownership, gates, resume handoff, convention that WIP commits never merge to main
+- [ ] **workflow** | Session detection at chat start — Claude Chat reads CLAUDE.md + REVIEW.md proactively at start of every chat, not just planning sessions
+- [ ] **workflow** | Out-of-session signal convention — Phi says "we're out of session" to shift Claude Chat into capture-only mode
+- [ ] **workflow** | Multi-chat context convention — active feature session lives in its own chat; all other chats default to capture-only mode
+- [ ] **workflow** | Design session close sweep — Claude Chat sweeps chat for uncaptured emergent items AND checks for items made obsolete by decisions made during the session, before generating Claude Code prompt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,18 @@ Every planning session, Claude Chat should automatically run through this checkl
 ## Capture Log
 A dedicated chat in this Claude project named "Capture Log — MTG Deck Builder" is the single place for all bugs, ideas, features, and UI tweaks captured between planning sessions. At the start of every planning session, Claude Chat and Phi review the Capture Log together and promote items into the Claude Code prompt and CLAUDE.md update instructions. Claude Code never reads the Capture Log directly — Claude Chat handles the triage and includes everything explicitly in the prompt.
 
+Before each planning session: open Capture Log chat, ask Claude Chat to consolidate new items into a Claude Code prompt, run the prompt, Claude Code bundles BACKLOG.md into the session commit, sync project files, then start the planning session.
+Drop a timestamp marker in Capture Log after each consolidation: `--- consolidated to BACKLOG.md [date] ---`
+
+---
+
+## BACKLOG.md
+Temporary capture scratch pad. Lives in the repo root. Items are promoted to the Backlog section of CLAUDE.md (with GitHub issue numbers) during planning sessions, then cleared from BACKLOG.md.
+- Claude Code appends items using format: `- [ ] **label** | description`
+- Valid labels: bug · feature · enhancement · chore · workflow
+- workflow items get folded into CLAUDE.md directly — no GitHub issue created
+- BACKLOG.md is bundled into the final session commit alongside CLAUDE.md, CHANGELOG.md, REVIEW.md
+
 ---
 
 ## How This File Works
@@ -120,7 +132,7 @@ New ideas captured here first, then promoted to a milestone when ready to build.
 
 7. Claude Code writes session summary to REVIEW.md, then commits:
    - `vX.X.X - description - Closes #N, Closes #N`
-   - `git add CLAUDE.md CHANGELOG.md REVIEW.md && git commit -m "update CLAUDE.md, CHANGELOG.md, and REVIEW.md post vX.X.X"`
+   - `git add CLAUDE.md CHANGELOG.md REVIEW.md BACKLOG.md && git commit -m "update CLAUDE.md, CHANGELOG.md, REVIEW.md, and BACKLOG.md post vX.X.X"`
 
 8. `git checkout main && git merge vX.X.X && git push`
 
@@ -150,6 +162,12 @@ Run through these on every design session:
 - [ ] Are tooltips only on non-obvious controls? Remove from universally understood icons (X, +, −).
 - [ ] Are tooltips consistent across all views (grid, list, modal) for the same control?
 - [ ] Do all tooltips have a max-width cap to prevent clipping?
+
+### Session Close Sweep
+Before generating the Claude Code prompt, Claude Chat sweeps the full chat session for:
+- Any emergent items discussed but not explicitly folded into CLAUDE.md — fold them in now or flag for Capture Log
+- Any previously captured items made obsolete by decisions made during this session — remove or update them
+No chat session ends without this sweep completing.
 
 ---
 
@@ -198,3 +216,4 @@ src/
 - REVIEW.md is the live session journal — written by Claude Code, read by all three parties. Never committed mid-session. Committed alongside CLAUDE.md and CHANGELOG.md at session end.
 - Plan Review step: Claude Code always outputs a plan table to REVIEW.md before touching any files, then waits for PROCEED
 - Capture Log chat URL: https://claude.ai/chat/39f0cbd5-b1f5-4995-8b54-c0f6769fcec7 — always find via recent_chats tool (not conversation_search by keyword, which is unreliable for finding it). recent_chats returns summaries that include all logged items.
+- BACKLOG.md is the between-session capture scratch pad — promoted items move to CLAUDE.md Backlog with issue numbers, then cleared. Bundled into the final session commit alongside the other 3 files.


### PR DESCRIPTION
## Summary
This PR establishes the BACKLOG.md file as the official between-session capture scratch pad and documents the complete workflow for triaging captured items during planning sessions. It also introduces a mandatory Session Close Sweep procedure to ensure no emergent items or obsolete decisions are left unaddressed.

## Key Changes

- **Introduced BACKLOG.md**: A new temporary capture file that lives in the repo root where Claude Code appends items using a standardized format (`- [ ] **label** | description`). Items are promoted to CLAUDE.md with GitHub issue numbers during planning sessions, then cleared.

- **Defined item labels**: Established five valid label categories (bug, feature, enhancement, chore, workflow) with special handling for workflow items that fold directly into CLAUDE.md without creating GitHub issues.

- **Updated planning session workflow**: Added explicit pre-session steps including opening the Capture Log, consolidating items into a Claude Code prompt, bundling BACKLOG.md into the session commit, and syncing project files.

- **Added consolidation markers**: Introduced timestamp markers (`--- consolidated to BACKLOG.md [date] ---`) to track when items are consolidated from the Capture Log.

- **Introduced Session Close Sweep**: New mandatory procedure where Claude Chat sweeps the full chat session before generating the Claude Code prompt to catch emergent items and identify obsolete decisions.

- **Updated git commit conventions**: Modified the final session commit to include BACKLOG.md alongside CLAUDE.md, CHANGELOG.md, and REVIEW.md.

- **Added initial BACKLOG.md**: Created the file with 8 feature/enhancement items and 5 workflow items as examples of the capture format.

## Notable Implementation Details

- BACKLOG.md is explicitly excluded from Claude Code's direct reads—Claude Chat handles all triage and includes items explicitly in prompts
- Workflow items bypass the GitHub issue creation process and are folded directly into CLAUDE.md
- The Session Close Sweep is a non-negotiable gate before any Claude Code prompt generation to maintain consistency between chat discussions and captured items

https://claude.ai/code/session_01JxohqSUsNQKCZ7xUo9xk5r