### PR TITLE
feat: mobile sidebar as off-canvas drawer (v1.24.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.24.0] — Mobile sidebar drawer
+
+### Added
+- **Mobile off-canvas drawer** — the sidebar now slides in from the left over a dimmed backdrop on screens below `md` (768px) instead of stacking at the top at `h-[40vh]`; it defaults closed so the workspace gets the full viewport height
+- **Mobile top bar** with a hamburger (`Menu`) button to open the drawer; the bar shows the current context — active deck name, `Settings`, or `Brew`
+
+### Changed
+- **Drawer dismissal**: closes via the backdrop tap, an `X` button in the drawer header, the Escape key, and automatically after navigation (selecting a deck, going home, or opening Settings)
+- **Layout split** now driven by Tailwind `md:` breakpoint classes (`fixed` drawer below `md`, in-flow `md:static` above) rather than the JS `isDesktop` flag, so desktop no longer risks a drawer flash on load
+
+### Unchanged
+- **Desktop sidebar** — the collapse-to-rail (48px ⇄ 256px) behavior is identical at ≥768px
+
+---
+
 ## [1.23.1] — Wheel-scroll regression fix + loading spinner
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Default to direct work. Tier up only when the change earns it.
 
 ## Current Version
 
-`v1.23.1` — Wheel-scroll regression fix on search-preview art strip + loading spinner overlay on slow Scryfall queries.
+`v1.24.0` — Mobile sidebar is now a true off-canvas drawer (slides in from the left, hamburger top bar, backdrop/Escape/auto-close); desktop collapse-to-rail unchanged.
 
 ## Post-Version Checklist
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState, useEffect, useCallback } from "react";
+import { Menu } from "lucide-react";
 import Sidebar from "@/components/layout/Sidebar";
 import Workspace from "@/components/workspace/Workspace";
 import SettingsView from "@/components/workspace/SettingsView";
@@ -58,6 +59,7 @@ export default function Dashboard() {
   const [isDragActive, setIsDragActive] = useState(false);
   const dragDepthRef = useRef(0);
   const [tileSize, setTileSizeState] = useState<TileSizeKey>(DEFAULT_TILE_SIZE);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
 
   const showToast = useCallback((message: string, durationMs = 2000) => {
     if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
@@ -79,7 +81,18 @@ export default function Dashboard() {
   const openSettings = (tab: "preferences" | "whatsnew" | "about" | "support") => {
     setSettingsTab(tab);
     setShowSettings(true);
+    setMobileSidebarOpen(false);
   };
+
+  // Escape closes the mobile drawer.
+  useEffect(() => {
+    if (!mobileSidebarOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMobileSidebarOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [mobileSidebarOpen]);
 
   // Restore persisted preferences + clean up stale search-workspace keys
   useEffect(() => {
@@ -386,7 +399,7 @@ export default function Dashboard() {
   };
 
   return (
-    <div className="min-h-screen bg-surface-base text-content-heading flex flex-col md:flex-row overflow-hidden font-sans">
+    <div className="h-screen bg-surface-base text-content-heading flex overflow-hidden font-sans">
       <Sidebar
         onImport={() => fileInputRef.current?.click()}
         onExport={exportDeck}
@@ -394,8 +407,10 @@ export default function Dashboard() {
         onOpenSettings={openSettings}
         showSettings={showSettings}
         onCloseSettings={() => setShowSettings(false)}
-        onGoHome={() => { setActiveDeckId(null); setShowSettings(false); }}
+        onGoHome={() => { setActiveDeckId(null); setShowSettings(false); setMobileSidebarOpen(false); }}
         isOnHomeScreen={!activeDeck && !showSettings}
+        mobileOpen={mobileSidebarOpen}
+        onMobileClose={() => setMobileSidebarOpen(false)}
       />
 
       <input
@@ -406,35 +421,51 @@ export default function Dashboard() {
         accept=".txt"
       />
 
-      <main className="flex-1 h-[60vh] md:h-screen flex flex-col overflow-hidden">
-        {showSettings ? (
-          <SettingsView
-            activeTab={settingsTab}
-            onTabChange={setSettingsTab}
-            onClose={() => setShowSettings(false)}
-            showToast={showToast}
-          />
-        ) : !activeDeck ? (
-          <HomeScreen
-            decks={decks}
-            onDeckSelect={(id) => { setActiveDeckId(id); }}
-            onCreateDeck={(format) => { createNewDeck(format); }}
-          />
-        ) : (
-          <div className="flex-1 overflow-hidden p-4">
-            <Workspace
-              pendingImport={pendingImport}
-              processImport={processImport}
-              cancelImport={cancelImport}
-              tileSize={tileSize}
-              onTileSizeChange={setTileSize}
+      <div className="flex-1 flex flex-col h-screen overflow-hidden min-w-0">
+        {/* Mobile top bar — hamburger opens the sidebar drawer; hidden on desktop */}
+        <div className="md:hidden flex items-center gap-2 px-2 h-12 shrink-0 border-b border-line-panel bg-surface-panel">
+          <button
+            onClick={() => setMobileSidebarOpen(true)}
+            aria-label="Open menu"
+            className="w-9 h-9 flex items-center justify-center rounded-md text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
+          >
+            <Menu className="w-5 h-5" />
+          </button>
+          <span className="text-sm font-medium text-content-heading truncate">
+            {showSettings ? "Settings" : activeDeck ? activeDeck.name : "Brew"}
+          </span>
+        </div>
+
+        <main className="flex-1 flex flex-col overflow-hidden">
+          {showSettings ? (
+            <SettingsView
+              activeTab={settingsTab}
+              onTabChange={setSettingsTab}
+              onClose={() => setShowSettings(false)}
               showToast={showToast}
-              registerCardPreviewFn={(fn) => { cardPreviewFnRef.current = fn; }}
-              onFindBarActiveChange={(active) => { isFindBarActiveRef.current = active; }}
             />
-          </div>
-        )}
-      </main>
+          ) : !activeDeck ? (
+            <HomeScreen
+              decks={decks}
+              onDeckSelect={(id) => { setActiveDeckId(id); }}
+              onCreateDeck={(format) => { createNewDeck(format); }}
+            />
+          ) : (
+            <div className="flex-1 overflow-hidden p-4">
+              <Workspace
+                pendingImport={pendingImport}
+                processImport={processImport}
+                cancelImport={cancelImport}
+                tileSize={tileSize}
+                onTileSizeChange={setTileSize}
+                showToast={showToast}
+                registerCardPreviewFn={(fn) => { cardPreviewFnRef.current = fn; }}
+                onFindBarActiveChange={(active) => { isFindBarActiveRef.current = active; }}
+              />
+            </div>
+          )}
+        </main>
+      </div>
 
       <DropOverlay visible={isDragActive} />
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Layers, PanelRightOpen, Settings, Home } from "lucide-react";
+import { Layers, PanelRightOpen, Settings, Home, X } from "lucide-react";
 import { APP_VERSION } from "@/config/version";
 import SidebarRail from "./SidebarRail";
 import SidebarDecksTab from "./SidebarDecksTab";
@@ -15,9 +15,11 @@ interface Props {
   onCloseSettings?: () => void;
   onGoHome: () => void;
   isOnHomeScreen: boolean;
+  mobileOpen: boolean;
+  onMobileClose: () => void;
 }
 
-export default function Sidebar({ onImport, onExport, isImporting, onOpenSettings, onCloseSettings, onGoHome, isOnHomeScreen }: Props) {
+export default function Sidebar({ onImport, onExport, isImporting, onOpenSettings, onCloseSettings, onGoHome, isOnHomeScreen, mobileOpen, onMobileClose }: Props) {
   const [collapsed, setCollapsed] = useState(false);
   const [isDesktop, setIsDesktop] = useState(false);
 
@@ -47,17 +49,32 @@ export default function Sidebar({ onImport, onExport, isImporting, onOpenSetting
   const isCollapsed = isDesktop && collapsed;
 
   return (
-    <aside
-      className={`h-[40vh] md:h-screen border-b md:border-b-0 md:border-r border-line-panel bg-surface-panel flex flex-col ${isCollapsed ? "overflow-visible" : "overflow-hidden"}`}
-      style={
-        isDesktop
-          ? {
-              width: isCollapsed ? 48 : 256,
-              transition: "width 300ms cubic-bezier(0.4, 0, 0.2, 1)",
-            }
-          : { width: "100%" }
-      }
-    >
+    <>
+      {/* Mobile backdrop — only rendered below md, fades with the drawer */}
+      <div
+        className={`fixed inset-0 z-40 bg-black/50 md:hidden transition-opacity duration-300 ${
+          mobileOpen ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
+        onClick={onMobileClose}
+        aria-hidden="true"
+      />
+      <aside
+        className={`
+          bg-surface-panel border-line-panel flex flex-col overflow-hidden
+          fixed inset-y-0 left-0 z-50 w-[82vw] max-w-[320px] border-r shadow-2xl
+          transition-transform duration-300 ${mobileOpen ? "translate-x-0" : "-translate-x-full"}
+          md:static md:z-auto md:h-screen md:w-auto md:max-w-none md:translate-x-0 md:shadow-none
+          ${isCollapsed ? "md:overflow-visible" : "md:overflow-hidden"}
+        `}
+        style={
+          isDesktop
+            ? {
+                width: isCollapsed ? 48 : 256,
+                transition: "width 300ms cubic-bezier(0.4, 0, 0.2, 1)",
+              }
+            : undefined
+        }
+      >
       {isCollapsed ? (
         <SidebarRail expandTo={expandTo} onOpenSettings={onOpenSettings} onGoHome={onGoHome} isOnHomeScreen={isOnHomeScreen} />
       ) : (
@@ -77,12 +94,21 @@ export default function Sidebar({ onImport, onExport, isImporting, onOpenSetting
               </button>
             )}
             {!isDesktop && (
-              <button
-                onClick={() => onOpenSettings("preferences")}
-                className="w-9 h-9 flex items-center justify-center bg-surface-deep border-b border-line-subtle text-content-muted hover:text-content-primary transition-colors"
-              >
-                <Settings className="w-4 h-4" />
-              </button>
+              <>
+                <button
+                  onClick={() => onOpenSettings("preferences")}
+                  className="w-9 h-9 flex items-center justify-center bg-surface-deep border-b border-line-subtle text-content-muted hover:text-content-primary transition-colors"
+                >
+                  <Settings className="w-4 h-4" />
+                </button>
+                <button
+                  onClick={onMobileClose}
+                  aria-label="Close menu"
+                  className="w-9 h-9 flex items-center justify-center bg-surface-deep border-b border-line-subtle text-content-muted hover:text-content-primary transition-colors"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </>
             )}
           </div>
 
@@ -92,6 +118,7 @@ export default function Sidebar({ onImport, onExport, isImporting, onOpenSetting
               onExport={onExport}
               isImporting={isImporting}
               onCloseSettings={onCloseSettings}
+              onNavigate={onMobileClose}
             />
           </div>
 
@@ -120,6 +147,7 @@ export default function Sidebar({ onImport, onExport, isImporting, onOpenSetting
           </div>
         </div>
       )}
-    </aside>
+      </aside>
+    </>
   );
 }

--- a/src/components/layout/SidebarDecksTab.tsx
+++ b/src/components/layout/SidebarDecksTab.tsx
@@ -12,6 +12,9 @@ interface Props {
   onExport: () => void;
   isImporting: boolean;
   onCloseSettings?: () => void;
+  // Called on any in-sidebar navigation (deck select, sideboard view, new deck)
+  // so the mobile drawer can close itself.
+  onNavigate?: () => void;
 }
 
 interface ConfirmDialogState {
@@ -20,7 +23,7 @@ interface ConfirmDialogState {
   targetFormat: DeckFormat;
 }
 
-export default function SidebarDecksTab({ onImport, onExport, isImporting, onCloseSettings }: Props) {
+export default function SidebarDecksTab({ onImport, onExport, isImporting, onCloseSettings, onNavigate }: Props) {
   const {
     decks,
     activeDeck,
@@ -152,6 +155,7 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
                     setDeckViewMode("main");
                   }
                   onCloseSettings?.();
+                  onNavigate?.();
                 }}
                 className={`flex-1 text-left text-xs truncate transition-colors min-w-0 ${
                   isActive ? "text-content-primary" : "text-content-tertiary hover:text-content-primary"
@@ -213,6 +217,7 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
                   if (!hasSideboard) enableSideboard(deck.id);
                   setDeckViewMode("sideboard");
                   onCloseSettings?.();
+                  onNavigate?.();
                 }}
                 disabled={isCommander}
                 title={
@@ -301,6 +306,7 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
                 onSelect={(format) => {
                   createNewDeck(format);
                   setNewDeckPickerOpen(false);
+                  onNavigate?.();
                 }}
               />
             </div>

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,10 +1,16 @@
 // Keep in sync with `Current Version` in CLAUDE.md and CHANGELOG.md.
 // Three files change together on every version bump.
-export const APP_VERSION = "1.23.1";
+export const APP_VERSION = "1.24.0";
 
 // Each entry is an array of bullet points — one string per item.
 // New versions should follow this same format.
 export const CHANGELOG: Record<string, string[]> = {
+  "1.24.0": [
+    "Feature: mobile sidebar is now a true off-canvas drawer — slides in from the left over a dimmed backdrop instead of stacking at the top of the screen; defaults closed so the workspace gets the full viewport height on phones",
+    "Feature: mobile top bar with a hamburger button opens the drawer; the bar shows the current context (active deck name, 'Settings', or 'Brew'); hidden on desktop (≥768px)",
+    "Enhancement: drawer auto-closes after selecting a deck, going home, or opening Settings, and dismisses via the backdrop, an X button in the drawer header, or the Escape key",
+    "Chore: desktop layout unchanged — the collapse-to-rail sidebar still renders in-flow at ≥768px; mobile/desktop split is now driven by Tailwind md: breakpoints to avoid a load flash",
+  ],
   "1.23.1": [
     "Fix: mouse-wheel horizontal scroll on the search-preview art strip — regressed under React 19 (onWheel registered as passive, so the parent panel's overflow-y-auto was eating the wheel event); restored via a window-level non-passive wheel listener delegated to [data-art-strip]",
     "Enhancement: loading spinner overlay on the search-preview panel and on the artist/set browse strip — Loader2 icon centered over the existing skeleton placeholders so slow Scryfall queries get a clear in-flight indicator",


### PR DESCRIPTION
## What

On screens below `md` (768px) the sidebar is now a **true off-canvas drawer** instead of a 40vh slab stacked at the top.

- **Mobile (< 768px)**: sidebar is a fixed drawer that slides in from the left over a dimmed backdrop, defaulting closed so the workspace gets the full viewport height
- **Mobile top bar** with a hamburger (`Menu`) opens it; the bar shows the current context — active deck name, `Settings`, or `Brew`
- **Dismissal**: backdrop tap, an `X` in the drawer header, the Escape key, and auto-close after navigation (deck select, sideboard view, new deck, go home, open settings)
- **Desktop (≥ 768px)**: collapse-to-rail behavior is unchanged

## How

- Mobile/desktop split is driven by Tailwind `md:` breakpoint classes (`fixed` drawer below `md`, `md:static` in-flow above) rather than the JS `isDesktop` flag — avoids a drawer flash on desktop load
- Auto-close on navigation is threaded through a small `onNavigate` callback into `SidebarDecksTab` (not a `setState`-in-effect), so it adds zero new lint violations
- Bumped to **v1.24.0** (`version.ts`, `CHANGELOG.md`, `CLAUDE.md` together)

## Verification

- `tsc --noEmit` — clean
- `eslint` on touched files — only the two pre-existing baseline violations remain (localStorage restore effects); no new ones added
- `next build` couldn't complete in the sandbox, but only because the network policy blocks fetching the Inter font from `fonts.googleapis.com` — environmental, not from this change. Will build on Vercel.

https://claude.ai/code/session_015vgsaNpWWbfqcBt7hEv66c

---
_Generated by [Claude Code](https://claude.ai/code/session_015vgsaNpWWbfqcBt7hEv66c)_