### PR TITLE
fix: mobile drawer layering + drop redundant hamburger label (v1.24.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.24.1] — Mobile drawer fixes
+
+### Fixed
+- **Drawer layering** — the open drawer and backdrop now sit above the deck's search bar and card price badges; raised to `z-[80]`/`z-[90]` (still below the `z-[100]` modals) so the search bar (`z-[60]`) and price chips (`z-[50]`) no longer bleed through on top
+- **Mobile top bar** — removed the deck-name label next to the hamburger; it's redundant with the large deck name already rendered in the workspace
+
+---
+
 ## [1.24.0] — Mobile sidebar drawer
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Default to direct work. Tier up only when the change earns it.
 
 ## Current Version
 
-`v1.24.0` — Mobile sidebar is now a true off-canvas drawer (slides in from the left, hamburger top bar, backdrop/Escape/auto-close); desktop collapse-to-rail unchanged.
+`v1.24.1` — Mobile drawer fixes: drawer/backdrop layered above the search bar and price chips; removed the redundant deck-name label next to the hamburger.
 
 ## Post-Version Checklist
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -423,7 +423,7 @@ export default function Dashboard() {
 
       <div className="flex-1 flex flex-col h-screen overflow-hidden min-w-0">
         {/* Mobile top bar — hamburger opens the sidebar drawer; hidden on desktop */}
-        <div className="md:hidden flex items-center gap-2 px-2 h-12 shrink-0 border-b border-line-panel bg-surface-panel">
+        <div className="md:hidden flex items-center px-2 h-12 shrink-0 border-b border-line-panel bg-surface-panel">
           <button
             onClick={() => setMobileSidebarOpen(true)}
             aria-label="Open menu"
@@ -431,9 +431,6 @@ export default function Dashboard() {
           >
             <Menu className="w-5 h-5" />
           </button>
-          <span className="text-sm font-medium text-content-heading truncate">
-            {showSettings ? "Settings" : activeDeck ? activeDeck.name : "Brew"}
-          </span>
         </div>
 
         <main className="flex-1 flex flex-col overflow-hidden">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -50,9 +50,11 @@ export default function Sidebar({ onImport, onExport, isImporting, onOpenSetting
 
   return (
     <>
-      {/* Mobile backdrop — only rendered below md, fades with the drawer */}
+      {/* Mobile backdrop — only rendered below md, fades with the drawer.
+          z-[80] clears the persistent workspace chrome (search bar z-[60],
+          price badges z-[50]) but stays below the z-[100] modals/dialogs. */}
       <div
-        className={`fixed inset-0 z-40 bg-black/50 md:hidden transition-opacity duration-300 ${
+        className={`fixed inset-0 z-[80] bg-black/50 md:hidden transition-opacity duration-300 ${
           mobileOpen ? "opacity-100" : "pointer-events-none opacity-0"
         }`}
         onClick={onMobileClose}
@@ -61,7 +63,7 @@ export default function Sidebar({ onImport, onExport, isImporting, onOpenSetting
       <aside
         className={`
           bg-surface-panel border-line-panel flex flex-col overflow-hidden
-          fixed inset-y-0 left-0 z-50 w-[82vw] max-w-[320px] border-r shadow-2xl
+          fixed inset-y-0 left-0 z-[90] w-[82vw] max-w-[320px] border-r shadow-2xl
           transition-transform duration-300 ${mobileOpen ? "translate-x-0" : "-translate-x-full"}
           md:static md:z-auto md:h-screen md:w-auto md:max-w-none md:translate-x-0 md:shadow-none
           ${isCollapsed ? "md:overflow-visible" : "md:overflow-hidden"}

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,10 +1,14 @@
 // Keep in sync with `Current Version` in CLAUDE.md and CHANGELOG.md.
 // Three files change together on every version bump.
-export const APP_VERSION = "1.24.0";
+export const APP_VERSION = "1.24.1";
 
 // Each entry is an array of bullet points — one string per item.
 // New versions should follow this same format.
 export const CHANGELOG: Record<string, string[]> = {
+  "1.24.1": [
+    "Fix: mobile drawer layering — the open drawer and its backdrop now sit above the deck's search bar and card price badges (raised to z-[80]/z-[90], still below the z-[100] modals); previously the search bar (z-[60]) and price chips (z-[50]) bled through on top",
+    "Fix: removed the deck-name label next to the mobile hamburger — redundant with the large deck name already shown in the workspace",
+  ],
   "1.24.0": [
     "Feature: mobile sidebar is now a true off-canvas drawer — slides in from the left over a dimmed backdrop instead of stacking at the top of the screen; defaults closed so the workspace gets the full viewport height on phones",
     "Feature: mobile top bar with a hamburger button opens the drawer; the bar shows the current context (active deck name, 'Settings', or 'Brew'); hidden on desktop (≥768px)",


### PR DESCRIPTION
Follow-up fixes to the mobile sidebar drawer (v1.24.0).

## Fixed

- **Drawer layering** — when the drawer was open, the deck's search bar (`z-[60]`) and card price badges (`z-[50]`) bled through on top of it. These escape to the root stacking context (their parents aren't stacking contexts), so they competed directly with the drawer's old `z-50`. Raised the backdrop to `z-[80]` and the drawer to `z-[90]` — clears the persistent workspace chrome while staying below the `z-[100]` modals/dialogs. Desktop is unaffected (`md:z-auto` / `md:hidden` still apply).
- **Mobile top bar** — removed the deck-name label next to the hamburger; redundant with the large deck name already rendered in the workspace.

Bumped to **v1.24.1** (`version.ts`, `CHANGELOG.md`, `CLAUDE.md`).

## Verification

- `tsc --noEmit` — clean
- `eslint` — only the two pre-existing baseline violations remain; no new ones

https://claude.ai/code/session_015vgsaNpWWbfqcBt7hEv66c

---
_Generated by [Claude Code](https://claude.ai/code/session_015vgsaNpWWbfqcBt7hEv66c)_