### PR TITLE
feat: mobile drawer polish — inline hamburger, footer settings, close icon (v1.24.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.24.2] — Mobile drawer polish
+
+### Changed
+- **Inline hamburger** — in the deck view the mobile hamburger now sits to the left of the search bar (`FindByNameBar`) instead of on its own row, reclaiming a full row of vertical space; Home and Settings keep the slim top-bar hamburger since they have no search bar
+- **Settings location** — moved from the drawer's top tab bar to the footer, right-aligned on the same row as Home and the version badge (mobile only; desktop unchanged)
+- **Close icon** — the drawer close button now uses `PanelLeftClose` (matching the existing sidebar open/collapse icons) instead of a plain `X`
+
+---
+
 ## [1.24.1] — Mobile drawer fixes
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Default to direct work. Tier up only when the change earns it.
 
 ## Current Version
 
-`v1.24.1` — Mobile drawer fixes: drawer/backdrop layered above the search bar and price chips; removed the redundant deck-name label next to the hamburger.
+`v1.24.2` — Mobile drawer polish: hamburger inline left of the deck search bar (saves a row); Settings moved to the drawer footer; close button uses the PanelLeftClose icon.
 
 ## Post-Version Checklist
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -422,16 +422,20 @@ export default function Dashboard() {
       />
 
       <div className="flex-1 flex flex-col h-screen overflow-hidden min-w-0">
-        {/* Mobile top bar — hamburger opens the sidebar drawer; hidden on desktop */}
-        <div className="md:hidden flex items-center px-2 h-12 shrink-0 border-b border-line-panel bg-surface-panel">
-          <button
-            onClick={() => setMobileSidebarOpen(true)}
-            aria-label="Open menu"
-            className="w-9 h-9 flex items-center justify-center rounded-md text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
-          >
-            <Menu className="w-5 h-5" />
-          </button>
-        </div>
+        {/* Mobile top bar — hamburger opens the sidebar drawer; hidden on desktop.
+            Only shown on Home/Settings; the deck view renders the hamburger
+            inline to the left of the search bar (FindByNameBar) instead. */}
+        {(showSettings || !activeDeck) && (
+          <div className="md:hidden flex items-center px-2 h-12 shrink-0 border-b border-line-panel bg-surface-panel">
+            <button
+              onClick={() => setMobileSidebarOpen(true)}
+              aria-label="Open menu"
+              className="w-9 h-9 flex items-center justify-center rounded-md text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
+            >
+              <Menu className="w-5 h-5" />
+            </button>
+          </div>
+        )}
 
         <main className="flex-1 flex flex-col overflow-hidden">
           {showSettings ? (
@@ -458,6 +462,7 @@ export default function Dashboard() {
                 showToast={showToast}
                 registerCardPreviewFn={(fn) => { cardPreviewFnRef.current = fn; }}
                 onFindBarActiveChange={(active) => { isFindBarActiveRef.current = active; }}
+                onOpenMobileSidebar={() => setMobileSidebarOpen(true)}
               />
             </div>
           )}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Layers, PanelRightOpen, Settings, Home, X } from "lucide-react";
+import { Layers, PanelRightOpen, Settings, Home, PanelLeftClose } from "lucide-react";
 import { APP_VERSION } from "@/config/version";
 import SidebarRail from "./SidebarRail";
 import SidebarDecksTab from "./SidebarDecksTab";
@@ -96,21 +96,13 @@ export default function Sidebar({ onImport, onExport, isImporting, onOpenSetting
               </button>
             )}
             {!isDesktop && (
-              <>
-                <button
-                  onClick={() => onOpenSettings("preferences")}
-                  className="w-9 h-9 flex items-center justify-center bg-surface-deep border-b border-line-subtle text-content-muted hover:text-content-primary transition-colors"
-                >
-                  <Settings className="w-4 h-4" />
-                </button>
-                <button
-                  onClick={onMobileClose}
-                  aria-label="Close menu"
-                  className="w-9 h-9 flex items-center justify-center bg-surface-deep border-b border-line-subtle text-content-muted hover:text-content-primary transition-colors"
-                >
-                  <X className="w-4 h-4" />
-                </button>
-              </>
+              <button
+                onClick={onMobileClose}
+                aria-label="Close menu"
+                className="w-9 h-9 flex items-center justify-center bg-surface-deep border-b border-line-subtle text-content-muted hover:text-content-primary transition-colors"
+              >
+                <PanelLeftClose className="w-4 h-4" />
+              </button>
             )}
           </div>
 
@@ -145,6 +137,15 @@ export default function Sidebar({ onImport, onExport, isImporting, onOpenSetting
               >
                 v{APP_VERSION}
               </button>
+              {!isDesktop && (
+                <button
+                  onClick={() => onOpenSettings("preferences")}
+                  className="ml-auto w-7 h-7 rounded-md flex items-center justify-center text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
+                  title="Settings"
+                >
+                  <Settings className="w-3.5 h-3.5" />
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/workspace/FindByNameBar.tsx
+++ b/src/components/workspace/FindByNameBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useLayoutEffect, useRef, useCallback, useMemo } from "react";
-import { Search, X, RotateCw, AlertTriangle, Loader2 } from "lucide-react";
+import { Search, X, RotateCw, AlertTriangle, Loader2, Menu } from "lucide-react";
 import { autocompleteCards, searchCards, getCardPrintings } from "@/lib/scryfall";
 import { useDeckManager } from "@/hooks/useDeckManager";
 import { parseDroppedText } from "@/hooks/useDeckImportExport";
@@ -17,6 +17,9 @@ interface FindByNameBarProps {
   registerOpenWithCardFn?: (fn: (card: DeckCard) => void) => void;
   onSwapArt?: (deckCard: DeckCard, newPrinting: ScryfallCard) => void;
   onActiveChange?: (active: boolean) => void;
+  // Mobile-only: renders a hamburger to the left of the search box that opens
+  // the sidebar drawer (so the deck view doesn't need a separate top-bar row).
+  onOpenMobileSidebar?: () => void;
 }
 
 function renderManaSymbols(manaCost: string | undefined): React.ReactNode {
@@ -63,7 +66,7 @@ function renderOracleText(text: string | undefined): React.ReactNode {
   );
 }
 
-export default function FindByNameBar({ showToast, registerFocusFn, registerSearchFn, registerDismissFn, registerCardPreviewFn, registerOpenWithCardFn, onSwapArt, onActiveChange }: FindByNameBarProps) {
+export default function FindByNameBar({ showToast, registerFocusFn, registerSearchFn, registerDismissFn, registerCardPreviewFn, registerOpenWithCardFn, onSwapArt, onActiveChange, onOpenMobileSidebar }: FindByNameBarProps) {
   const { activeDeck, updateActiveDeck, deckViewMode, setLastAddedId } = useDeckManager();
 
   const inputRef = useRef<HTMLInputElement>(null);
@@ -605,8 +608,19 @@ export default function FindByNameBar({ showToast, registerFocusFn, registerSear
 
   return (
     <div ref={containerRef} className="relative shrink-0 bg-surface-base z-[60] px-3 py-2">
+      {/* Row: mobile hamburger (left) + the styled input box */}
+      <div className="flex items-center gap-2">
+      {onOpenMobileSidebar && (
+        <button
+          onClick={onOpenMobileSidebar}
+          aria-label="Open menu"
+          className="md:hidden w-9 h-9 shrink-0 flex items-center justify-center rounded-md text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
+        >
+          <Menu className="w-5 h-5" />
+        </button>
+      )}
       {/* Header row — visually styled input box */}
-      <div className={`flex items-center gap-2 px-3 h-11 rounded-xl border bg-surface-panel ${inputFocused || showPreview ? "border-line-focus" : "border-line-subtle"}`}>
+      <div className={`flex-1 flex items-center gap-2 px-3 h-11 rounded-xl border bg-surface-panel ${inputFocused || showPreview ? "border-line-focus" : "border-line-subtle"}`}>
         <Search className="w-4 h-4 text-content-muted shrink-0" />
         <input
           ref={inputRef}
@@ -663,6 +677,7 @@ export default function FindByNameBar({ showToast, registerFocusFn, registerSear
             <X className="w-3.5 h-3.5" />
           </button>
         )}
+      </div>
       </div>
 
       {/* Autocomplete dropdown */}

--- a/src/components/workspace/Workspace.tsx
+++ b/src/components/workspace/Workspace.tsx
@@ -24,6 +24,7 @@ interface WorkspaceProps {
   showToast: (msg: string) => void;
   registerCardPreviewFn?: (fn: (name: string, setCode?: string) => void) => void;
   onFindBarActiveChange?: (active: boolean) => void;
+  onOpenMobileSidebar?: () => void;
 }
 
 // Color sort: WUBRG mono → multicolor (by combination) → colorless/missing
@@ -51,7 +52,7 @@ interface ConfirmDialogState {
   targetFormat: DeckFormat;
 }
 
-export default function Workspace({ pendingImport, processImport, cancelImport, tileSize, onTileSizeChange, showToast, registerCardPreviewFn, onFindBarActiveChange }: WorkspaceProps) {
+export default function Workspace({ pendingImport, processImport, cancelImport, tileSize, onTileSizeChange, showToast, registerCardPreviewFn, onFindBarActiveChange, onOpenMobileSidebar }: WorkspaceProps) {
   const {
     decks,
     activeDeck,
@@ -528,6 +529,7 @@ export default function Workspace({ pendingImport, processImport, cancelImport, 
           setIsFindBarActive(active);
           onFindBarActiveChange?.(active);
         }}
+        onOpenMobileSidebar={onOpenMobileSidebar}
       />
       {isFindBarActive && (
         <div

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,10 +1,15 @@
 // Keep in sync with `Current Version` in CLAUDE.md and CHANGELOG.md.
 // Three files change together on every version bump.
-export const APP_VERSION = "1.24.1";
+export const APP_VERSION = "1.24.2";
 
 // Each entry is an array of bullet points — one string per item.
 // New versions should follow this same format.
 export const CHANGELOG: Record<string, string[]> = {
+  "1.24.2": [
+    "Enhancement: on mobile the deck view's hamburger now sits inline to the left of the search bar instead of on its own row — reclaims a full row of vertical space; Home and Settings keep the slim top-bar hamburger (no search bar there)",
+    "Enhancement: mobile drawer Settings moved from the top tab bar to the footer, right-aligned on the same row as Home and the version badge — groups the meta actions together",
+    "Enhancement: mobile drawer close button now uses the PanelLeftClose icon (matching the sidebar open/collapse icons) instead of a plain X",
+  ],
   "1.24.1": [
     "Fix: mobile drawer layering — the open drawer and its backdrop now sit above the deck's search bar and card price badges (raised to z-[80]/z-[90], still below the z-[100] modals); previously the search bar (z-[60]) and price chips (z-[50]) bled through on top",
     "Fix: removed the deck-name label next to the mobile hamburger — redundant with the large deck name already shown in the workspace",


### PR DESCRIPTION
Follow-up polish to the mobile sidebar drawer.

## Changed

- **Inline hamburger (deck view)** — the mobile hamburger now sits to the left of the search bar (`FindByNameBar`) instead of on its own row, reclaiming a full row of vertical space. The slim top-bar hamburger is kept only on **Home** and **Settings**, which have no search bar. Hamburger stays top-left everywhere.
- **Settings → footer** — moved from the drawer's top tab bar to the footer, right-aligned (`ml-auto`) on the same row as Home and the version badge. This groups the meta actions together. Mobile only; desktop footer unchanged.
- **Close icon** — the drawer close button now uses `PanelLeftClose` (consistent with the existing `PanelLeftOpen` / `PanelRightOpen` sidebar icons) instead of a plain `X`.

Threaded `onOpenMobileSidebar` through `page.tsx` → `Workspace` → `FindByNameBar`.

Bumped to **v1.24.2** (`version.ts`, `CHANGELOG.md`, `CLAUDE.md`).

## Verification

- `tsc --noEmit` — clean
- `eslint` — no new issues; remaining errors/warnings are all pre-existing (baseline `setState`-in-effect, and `FindByNameBar`'s long-standing `<img>`/unescaped-quote/unused-var lint in untouched code)

https://claude.ai/code/session_015vgsaNpWWbfqcBt7hEv66c

---
_Generated by [Claude Code](https://claude.ai/code/session_015vgsaNpWWbfqcBt7hEv66c)_