### PR TITLE
feat: mobile deck controls in a Tools bottom sheet (v1.25.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.25.0] — Mobile deck controls
+
+### Added
+- **Mobile Tools sheet** — the deck toolbar's right-side control block (Simulator, Main/Side, Sort, Group, card size, Grid/List) was a fixed-width inline bar that ran far wider than a phone viewport, so on mobile it overflowed off the right edge with no way to scroll to it — the simulator, sort, grouping, and view toggles were all unreachable. Below `md` (768px) the block now collapses into a single **Tools** button (`SlidersHorizontal` icon) that opens a bottom sheet (`DeckToolsSheet`) listing every control as a full-width, finger-sized row
+
+### Changed
+- **Touch-friendly controls in the sheet** — each control group is a tap-target-sized segmented control: Main/Sideboard, Sort by (Original/Name/Color/Mana Value) + Ascending/Descending, Grouping (Flat / By type), Card size (XS–XL), and View (Grid / List). The card-size control is a segmented row rather than the desktop vertical slider, which is pointer-only (`mousedown`/`mouseup`). The Simulator row closes the sheet and opens the simulator modal
+- **Bottom-sheet behaviour** — slides up from the bottom over a dimmed backdrop (`sheet`-style `translate-y` transition), dismissed by tapping the backdrop or the `X`; body scroll is locked while open; respects `env(safe-area-inset-bottom)`
+- **Stats wrap, don't overflow** — the left-side stats (card count, Value, To Buy) are unchanged in content but now `flex-wrap` on narrow screens (`md:flex-nowrap md:shrink-0` keeps desktop identical) so the Tools button always stays on-screen
+
+### Unchanged
+- **Desktop (≥768px) toolbar** is byte-for-byte the same — the inline control bar still renders as before (`hidden md:flex`); the mobile/desktop split is driven entirely by `md:` breakpoints
+
+---
+
 ## [1.24.6] — Mobile preview close no longer pops the keyboard
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Default to direct work. Tier up only when the change earns it.
 
 ## Current Version
 
-`v1.24.6` — Closing the mobile full-screen search preview (the X) no longer re-focuses the search field, so the on-screen keyboard stays down instead of popping back up. Search-box clear X and desktop dismiss still refocus as before.
+`v1.25.0` — Deck controls are now reachable on mobile: below 768px the dense toolbar control block (Simulator, Main/Side, Sort, Group, card size, Grid/List) collapses into a single "Tools" button that opens a bottom sheet (`DeckToolsSheet`) with all controls as full-width, finger-sized rows. Card size uses a touch-friendly XS–XL segmented control (desktop slider is pointer-only). Left-side stats are unchanged but now wrap on narrow screens. Desktop toolbar unchanged (`hidden md:flex`).
 
 ## Post-Version Checklist
 

--- a/src/components/workspace/DeckToolsSheet.tsx
+++ b/src/components/workspace/DeckToolsSheet.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  LayoutGrid,
+  List,
+  Layout,
+  ArrowUp,
+  ArrowDown,
+  Dices,
+  X,
+} from "lucide-react";
+import { SortBy, SortDir } from "@/hooks/useDeckManager";
+import { DeckFormat } from "@/lib/formatRules";
+import { TILE_SIZE_STOPS, TileSizeKey } from "@/config/gridConfig";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  format: DeckFormat;
+  viewMode: "visual" | "list";
+  setViewMode: (v: "visual" | "list") => void;
+  sortBy: SortBy;
+  setSortBy: (by: SortBy) => void;
+  sortDir: SortDir;
+  setSortDir: (dir: SortDir) => void;
+  isGrouped: boolean;
+  setIsGrouped: (g: boolean) => void;
+  deckViewMode: "main" | "sideboard";
+  setDeckViewMode: (v: "main" | "sideboard") => void;
+  activeDeckHasSideboard: boolean;
+  onOpenSampleHand: () => void;
+  tileSize: TileSizeKey;
+  onTileSizeChange: (stop: TileSizeKey) => void;
+}
+
+const SORT_OPTIONS: { value: SortBy; label: string }[] = [
+  { value: "original", label: "Original" },
+  { value: "name", label: "Name" },
+  { value: "color", label: "Color" },
+  { value: "mv", label: "Mana Value" },
+];
+
+// Touch-friendly segmented control. The desktop toolbar packs these same
+// controls into a dense bar; on mobile they get full-width, finger-sized rows.
+function SegButton({
+  active,
+  onClick,
+  children,
+  disabled,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={`flex-1 h-10 px-2 flex items-center justify-center gap-1.5 text-sm rounded-md transition-all ${
+        active
+          ? "bg-blue-600 text-white border border-blue-500/50"
+          : disabled
+          ? "text-content-disabled cursor-not-allowed border border-transparent"
+          : "text-content-muted hover:text-content-secondary border border-transparent"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-2">
+      <span className="text-[10px] font-bold text-content-muted uppercase tracking-widest">
+        {label}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+export default function DeckToolsSheet({
+  open,
+  onClose,
+  format,
+  viewMode,
+  setViewMode,
+  sortBy,
+  setSortBy,
+  sortDir,
+  setSortDir,
+  isGrouped,
+  setIsGrouped,
+  deckViewMode,
+  setDeckViewMode,
+  activeDeckHasSideboard,
+  onOpenSampleHand,
+  tileSize,
+  onTileSizeChange,
+}: Props) {
+  // Lock body scroll while the sheet is open.
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  return (
+    <>
+      {/* Backdrop — z-[80] clears workspace chrome but sits below the z-[100]
+          Simulator modal that this sheet can launch. */}
+      <div
+        className={`fixed inset-0 z-[80] bg-black/50 md:hidden transition-opacity duration-300 ${
+          open ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      <div
+        role="dialog"
+        aria-label="Deck tools"
+        className={`fixed inset-x-0 bottom-0 z-[90] md:hidden bg-surface-panel border-t border-line-default rounded-t-2xl shadow-2xl transition-transform duration-300 ${
+          open ? "translate-y-0" : "translate-y-full"
+        }`}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 h-12 border-b border-line-subtle">
+          <span className="text-sm font-semibold text-content-heading">Deck tools</span>
+          <button
+            onClick={onClose}
+            aria-label="Close deck tools"
+            className="w-9 h-9 -mr-2 flex items-center justify-center text-content-muted hover:text-content-primary transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="px-4 py-4 space-y-5 pb-[max(1rem,env(safe-area-inset-bottom))]">
+          {/* Simulator — closes the sheet, then opens the modal */}
+          <button
+            onClick={() => {
+              onClose();
+              onOpenSampleHand();
+            }}
+            className="w-full h-11 flex items-center justify-center gap-2 bg-surface-base border border-line-subtle rounded-lg text-sm font-bold text-content-tertiary hover:text-content-primary hover:bg-surface-raised transition-colors"
+          >
+            <Dices className="w-4 h-4" />
+            Simulator
+          </button>
+
+          {/* Main / Side — hidden for Commander, matching the desktop toolbar */}
+          {format !== "commander" && (
+            <Section label="Cards">
+              <div className="flex items-center gap-1 bg-surface-base p-0.5 rounded-lg border border-line-subtle">
+                <SegButton active={deckViewMode === "main"} onClick={() => setDeckViewMode("main")}>
+                  Main
+                </SegButton>
+                <SegButton
+                  active={deckViewMode === "sideboard"}
+                  disabled={!activeDeckHasSideboard}
+                  onClick={() => activeDeckHasSideboard && setDeckViewMode("sideboard")}
+                >
+                  Sideboard
+                </SegButton>
+              </div>
+            </Section>
+          )}
+
+          {/* Sort */}
+          <Section label="Sort by">
+            <div className="grid grid-cols-2 gap-1 bg-surface-base p-0.5 rounded-lg border border-line-subtle">
+              {SORT_OPTIONS.map((opt) => (
+                <SegButton
+                  key={opt.value}
+                  active={sortBy === opt.value}
+                  onClick={() => setSortBy(opt.value)}
+                >
+                  {opt.label}
+                </SegButton>
+              ))}
+            </div>
+            <button
+              onClick={() => setSortDir(sortDir === "asc" ? "desc" : "asc")}
+              disabled={sortBy === "original"}
+              className={`w-full h-10 flex items-center justify-center gap-2 rounded-lg border text-sm transition-colors ${
+                sortBy === "original"
+                  ? "text-content-disabled border-line-subtle cursor-not-allowed"
+                  : "text-content-secondary border-line-subtle hover:bg-surface-raised"
+              }`}
+            >
+              {sortDir === "asc" ? (
+                <>
+                  <ArrowUp className="w-4 h-4" /> Ascending
+                </>
+              ) : (
+                <>
+                  <ArrowDown className="w-4 h-4" /> Descending
+                </>
+              )}
+            </button>
+          </Section>
+
+          {/* Group */}
+          <Section label="Grouping">
+            <div className="flex items-center gap-1 bg-surface-base p-0.5 rounded-lg border border-line-subtle">
+              <SegButton active={!isGrouped} onClick={() => setIsGrouped(false)}>
+                Flat
+              </SegButton>
+              <SegButton active={isGrouped} onClick={() => setIsGrouped(true)}>
+                <Layout className="w-4 h-4" /> By type
+              </SegButton>
+            </div>
+          </Section>
+
+          {/* Card size — segmented (the desktop slider is pointer-only) */}
+          <Section label="Card size">
+            <div className="flex items-center gap-1 bg-surface-base p-0.5 rounded-lg border border-line-subtle">
+              {TILE_SIZE_STOPS.map((stop) => (
+                <SegButton
+                  key={stop.key}
+                  active={tileSize === stop.key}
+                  onClick={() => onTileSizeChange(stop.key)}
+                >
+                  {stop.key.toUpperCase()}
+                </SegButton>
+              ))}
+            </div>
+          </Section>
+
+          {/* View */}
+          <Section label="View">
+            <div className="flex items-center gap-1 bg-surface-base p-0.5 rounded-lg border border-line-subtle">
+              <SegButton active={viewMode === "visual"} onClick={() => setViewMode("visual")}>
+                <LayoutGrid className="w-4 h-4" /> Grid
+              </SegButton>
+              <SegButton active={viewMode === "list"} onClick={() => setViewMode("list")}>
+                <List className="w-4 h-4" /> List
+              </SegButton>
+            </div>
+          </Section>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/workspace/WorkspaceToolbar.tsx
+++ b/src/components/workspace/WorkspaceToolbar.tsx
@@ -9,12 +9,14 @@ import {
   ArrowUp,
   ArrowDown,
   Dices,
+  SlidersHorizontal,
 } from "lucide-react";
 import { Deck } from "@/types";
 import { SortBy, SortDir, useDeckManager } from "@/hooks/useDeckManager";
 import { getFormatRules, DeckFormat } from "@/lib/formatRules";
 import { FormatPicker } from "@/components/layout/FormatPicker";
 import TileSizeSlider from "./TileSizeSlider";
+import DeckToolsSheet from "./DeckToolsSheet";
 import { TileSizeKey } from "@/config/gridConfig";
 
 interface Props {
@@ -73,6 +75,7 @@ export default function WorkspaceToolbar({
   onTileSizeChange,
 }: Props) {
   const [isEditingName, setIsEditingName] = useState(false);
+  const [mobileToolsOpen, setMobileToolsOpen] = useState(false);
   const [formatPickerOpen, setFormatPickerOpen] = useState(false);
   const [formatPickerDir, setFormatPickerDir] = useState<"up" | "down">("down");
   const formatPickerRef = useRef<HTMLDivElement>(null);
@@ -197,7 +200,7 @@ export default function WorkspaceToolbar({
 
       {/* Row 2: stats (left) + controls (right) */}
       <div className="flex items-center justify-between gap-4">
-        <div className="flex items-center gap-3 text-xs text-content-tertiary shrink-0">
+        <div className="flex items-center gap-3 text-xs text-content-tertiary flex-wrap min-w-0 md:shrink-0 md:flex-nowrap">
           {deckViewMode === "sideboard" ? (
             <span className={sideboardClass}>
               {format === "standard"
@@ -234,8 +237,19 @@ export default function WorkspaceToolbar({
           )}
         </div>
 
-      {/* Right: simulator + main/side + sort/group/view */}
-      <div className="flex items-center gap-2 h-8 shrink-0">
+      {/* Mobile: single Tools button — the dense desktop control block below
+          overflows the viewport, so on mobile it collapses into a bottom sheet. */}
+      <button
+        onClick={() => setMobileToolsOpen(true)}
+        aria-label="Deck tools"
+        className="md:hidden flex items-center justify-center gap-1.5 h-9 px-3 shrink-0 bg-surface-base border border-line-subtle rounded-lg text-xs font-bold text-content-tertiary hover:text-content-primary hover:bg-surface-raised transition-colors shadow-sm"
+      >
+        <SlidersHorizontal className="w-4 h-4" />
+        <span>Tools</span>
+      </button>
+
+      {/* Right: simulator + main/side + sort/group/view (desktop only) */}
+      <div className="hidden md:flex items-center gap-2 h-8 shrink-0">
         <button
           onClick={onOpenSampleHand}
           className="flex items-center gap-2 h-full px-3 bg-surface-base border border-line-subtle rounded-lg text-xs font-bold text-content-tertiary hover:text-content-primary hover:bg-surface-raised transition-colors shadow-sm"
@@ -364,6 +378,26 @@ export default function WorkspaceToolbar({
         </div>
       </div>
       </div>
+
+      <DeckToolsSheet
+        open={mobileToolsOpen}
+        onClose={() => setMobileToolsOpen(false)}
+        format={format}
+        viewMode={viewMode}
+        setViewMode={setViewMode}
+        sortBy={sortBy}
+        setSortBy={setSortBy}
+        sortDir={sortDir}
+        setSortDir={setSortDir}
+        isGrouped={isGrouped}
+        setIsGrouped={setIsGrouped}
+        deckViewMode={deckViewMode}
+        setDeckViewMode={setDeckViewMode}
+        activeDeckHasSideboard={activeDeckHasSideboard}
+        onOpenSampleHand={onOpenSampleHand}
+        tileSize={tileSize}
+        onTileSizeChange={onTileSizeChange}
+      />
     </div>
   );
 }

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,10 +1,16 @@
 // Keep in sync with `Current Version` in CLAUDE.md and CHANGELOG.md.
 // Three files change together on every version bump.
-export const APP_VERSION = "1.24.6";
+export const APP_VERSION = "1.25.0";
 
 // Each entry is an array of bullet points — one string per item.
 // New versions should follow this same format.
 export const CHANGELOG: Record<string, string[]> = {
+  "1.25.0": [
+    "Feature: deck controls are now reachable on mobile — the dense toolbar control block (Simulator, Main/Side, Sort, Group, card size, Grid/List) was wider than a phone screen and overflowed off the right edge with no way to reach it. Below 768px it now collapses into a single 'Tools' button that opens a bottom sheet with all of those controls as full-width, finger-sized rows.",
+    "Enhancement: the bottom sheet slides up from the bottom over a dimmed backdrop (tap the backdrop or the X to close); the Simulator row closes the sheet and opens the simulator modal. Card size uses a touch-friendly XS–XL segmented control inside the sheet (the desktop slider is pointer-only).",
+    "Enhancement: the deck stats on the left (card count, Value, To Buy) are unchanged but now wrap gracefully on very narrow screens so the Tools button always stays visible.",
+    "Chore: desktop (≥768px) toolbar is completely unchanged — the inline control bar still renders as before; the mobile/desktop split is driven by md: breakpoints.",
+  ],
   "1.24.6": [
     "Fix: closing the mobile full-screen search preview (the X) no longer re-focuses the search field, so the on-screen keyboard stays down instead of popping back up and swallowing the screen; the search box's clear X and desktop dismiss still refocus as before",
   ],


### PR DESCRIPTION
## Problem

The deck toolbar's second row puts stats on the left and a fixed-width control block on the right — **Simulator, Main/Side, Sort, Group, card size, Grid/List** — all marked `shrink-0`. That block is far wider than a phone viewport, so on mobile it overflowed off the right edge with **no way to reach any of it**. Desktop had room, so it worked fine.

## Fix

Below `md` (768px) the control block collapses into a single **Tools** button that opens a bottom sheet.

- **New `DeckToolsSheet.tsx`** — mobile-only bottom sheet that slides up over a dimmed backdrop, with every control as a full-width, finger-sized row: Simulator, Main/Sideboard, Sort by + direction, Grouping (Flat / By type), Card size (XS–XL), View (Grid / List). Card size is a segmented control because the desktop `TileSizeSlider` is pointer-only (`mousedown`/`mouseup`) and wouldn't work on touch. Tapping Simulator closes the sheet and opens the modal; body scroll locks while open; respects `env(safe-area-inset-bottom)`.
- **`WorkspaceToolbar.tsx`** — desktop control block is now `hidden md:flex`; a single **Tools** button (`SlidersHorizontal`) shows in its place below `md`. Left-side stats are unchanged in content but now `flex-wrap` on narrow screens (`md:flex-nowrap md:shrink-0` keeps desktop identical) so the Tools button always stays visible.
- **Desktop (≥768px) toolbar is unchanged** — the split is driven entirely by `md:` breakpoints.
- Bumped to **v1.25.0** across `version.ts`, `CHANGELOG.md`, and `CLAUDE.md`.

## Verification

- `tsc --noEmit` passes clean
- ESLint passes (the one warning is pre-existing and unrelated)
- Production build only fails on fetching Google Fonts — a sandbox network restriction, not the code
- Not visually QA'd on a real mobile viewport (no browser in the sandbox); logic and breakpoints reviewed

https://claude.ai/code/session_01AiZiNFQUeG3UutNvbohMFg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiZiNFQUeG3UutNvbohMFg)_