### PR TITLE
Site-wide touch & sizing pass + grid-view editing on touch (v1.26.0–v1.27.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.27.0] — Grid-view editing on touch
+
+The follow-up flagged in 1.26.0: the visual (grid) card tile's edit controls lived inside a `group-hover` slide-up overlay, so on touch they never appeared and the overlay (when it did) covered ~45% of the art. Grid tiles are now editable on touch via a tap-to-reveal slim bar, at full parity with desktop. The design decision (tap the qty badge → slim bar, vs. long-press; full parity; crown as a corner tap) was made in-session.
+
+### Added
+- **`useIsTouch()` hook** (`src/hooks/useIsTouch.ts`) — single source of truth for `matchMedia("(hover: none)")`; `FindByNameBar`'s duplicated inline detection now uses it
+- **Touch edit bar on `VisualCard` (deck mode)** — tapping the always-on quantity badge reveals a slim, full-width bottom bar with full desktop parity: owned ✓ toggle, owned stepper, qty stepper (numbers are tap-to-edit), and remove. The bar is a thin bottom strip over a gradient (not the ~45% hover panel) and is always mounted so number inputs commit `onBlur`
+- **Crown as a corner tap** — in Commander decks the non-commander "set as commander/partner" crown is un-gated to always-visible on touch, instead of being folded into the bar
+
+### Changed
+- **Dismiss + non-overlap behaviour** — the bar closes on a tap on the art, a tap/scroll outside the card (`pointerdown` listener gated on `barOpen`), or a second tap on the badge; the badge and price pill hide while it's open
+- **Stable touch badge** — emulated `mouseenter` on tap no longer flips the badge to its desktop ✓/raised state (`badgeHoverActive = !isTouch && isCardHovered`), so on touch the badge stays a quantity chip / reveal trigger
+
+### Unchanged
+- **Desktop / pointer** behaviour is identical — the hover overlay, the badge-as-owned-toggle, hover steppers, and the top-right remove all work exactly as before; everything new is gated behind `isTouch`
+
+---
+
 ## [1.26.0] — Site-wide touch & sizing pass
 
 A systematic audit and pass over text, icon, spacing, and tap-target sizing across the whole app, with a single unified scale applied to desktop and touch alike (no responsive split). The standard is recorded in `docs/ARCHITECTURE.md` → **Touch & Sizing System** so new UI conforms instead of re-introducing ad-hoc values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.26.0] — Site-wide touch & sizing pass
+
+A systematic audit and pass over text, icon, spacing, and tap-target sizing across the whole app, with a single unified scale applied to desktop and touch alike (no responsive split). The standard is recorded in `docs/ARCHITECTURE.md` → **Touch & Sizing System** so new UI conforms instead of re-introducing ad-hoc values.
+
+### Fixed
+- **Hover-gated controls were unreachable on touch** — in list view, the quantity/owned steppers, the owned ✓ toggle, the row remove ✕, and the search-results **+** add button were all `opacity-0 group-hover:opacity-100`. Touch devices have no hover, so these never appeared and the actions were impossible. They're now always visible (subtle at rest, brighter on pointer hover), enlarged to ~28px hit areas, and the 6px inline `<svg>` glyphs were replaced with real 16px `lucide` `Minus`/`Plus` icons. The list qty column widened (`w-40`→`w-52`) to fit the larger steppers
+- **Sub-legible text everywhere** — every hardcoded `text-[8px]`/`text-[9px]`/`text-[10px]` (deck names, card counts, format badges, column headers, tooltips, mana-curve labels, legal copy, etc.) was promoted to the new floor: 11px for micro-labels, `text-xs` for secondary, `text-sm` for primary content
+
+### Changed
+- **44px tap targets** — standalone icon buttons across the chrome are now `h-11 w-11`: sidebar rail (6 buttons), sidebar collapse/close, footer home/settings, mobile hamburgers (`page.tsx`, `FindByNameBar`), settings back, simulator close, deck-tools close, mobile Tools button. Text/menu buttons gained `min-h-11`
+- **Dense inline controls** — `SidebarDecksTab` deck rows, delete/sideboard buttons, action strip (Export/Import/TCGPlayer/Card Kingdom), and `FilterPanel` chips/inputs/presets/slider got larger padding, 16px icons, and 11–14px text; the price-range slider thumb grew to 16px
+- **Icons normalised** — functional icons floored at 16px; nav/action icons 18–20px (`SidebarRail`, toolbar sort/group/view, search clear, color symbols, crowns)
+- **Home covers** — `DeckCoverCard`/`GhostDeckCard` enlarged to 120×168 with `text-xs`/11px labels; the home format picker now drops below the ghost card centered (was `left-full`, which clipped off-screen on narrow viewports)
+- **Desktop is intentionally slightly less dense** — per the "unify everything" decision, the same comfortable scale applies at all widths; the desktop toolbar control block stepped from `h-8`→`h-9` with 16px icons
+
+### Added
+- **Explicit viewport** — `layout.tsx` exports `viewport` with `viewportFit: "cover"` for iPad/notch safe-area insets (Next.js otherwise injects a default without it)
+- **Touch & Sizing System** section in `docs/ARCHITECTURE.md` documenting the text floor, icon sizes, tap-target rules, and the "never hover-gate an interactive control" rule
+
+### Known follow-up
+- The **visual (grid) card tile** reveals its name/type/steppers/crown inside a `group-hover` slide-up overlay, so inline editing there is still pointer-oriented on touch. Sizing within the overlay was bumped, but converting it to a tap-to-reveal interaction is a behavioural change with real UX decisions and is left as a planned follow-up rather than guessed at here
+
+---
+
 ## [1.25.0] — Mobile deck controls
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Default to direct work. Tier up only when the change earns it.
 
 ## Current Version
 
-`v1.25.0` — Deck controls are now reachable on mobile: below 768px the dense toolbar control block (Simulator, Main/Side, Sort, Group, card size, Grid/List) collapses into a single "Tools" button that opens a bottom sheet (`DeckToolsSheet`) with all controls as full-width, finger-sized rows. Card size uses a touch-friendly XS–XL segmented control (desktop slider is pointer-only). Left-side stats are unchanged but now wrap on narrow screens. Desktop toolbar unchanged (`hidden md:flex`).
+`v1.26.0` — Site-wide touch & sizing pass. One unified, finger-friendly scale across desktop and touch (no responsive split). Text floor is now 11px (every `text-[8/9/10px]` promoted by role); standalone chrome buttons are 44px (`h-11 w-11`); dense inline controls — the list-view qty/owned steppers, owned ✓ toggle, row remove ✕, and search-results add button — are no longer `opacity-0 group-hover` (which made them unreachable on iPad) and are now always visible at ~28px with real 16px `lucide` icons. Explicit `viewport-fit=cover` added in `layout.tsx`. The standard lives in `docs/ARCHITECTURE.md` → **Touch & Sizing System**. Known follow-up: the visual (grid) card tile still reveals its editing controls inside a `group-hover` overlay, so grid inline-editing on touch awaits a tap-to-reveal redesign (sizing was bumped; behaviour unchanged).
 
 ## Post-Version Checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,9 @@ Default to direct work. Tier up only when the change earns it.
 
 ## Current Version
 
-`v1.26.0` — Site-wide touch & sizing pass. One unified, finger-friendly scale across desktop and touch (no responsive split). Text floor is now 11px (every `text-[8/9/10px]` promoted by role); standalone chrome buttons are 44px (`h-11 w-11`); dense inline controls — the list-view qty/owned steppers, owned ✓ toggle, row remove ✕, and search-results add button — are no longer `opacity-0 group-hover` (which made them unreachable on iPad) and are now always visible at ~28px with real 16px `lucide` icons. Explicit `viewport-fit=cover` added in `layout.tsx`. The standard lives in `docs/ARCHITECTURE.md` → **Touch & Sizing System**. Known follow-up: the visual (grid) card tile still reveals its editing controls inside a `group-hover` overlay, so grid inline-editing on touch awaits a tap-to-reveal redesign (sizing was bumped; behaviour unchanged).
+`v1.27.0` — Grid-view editing on touch (the 1.26.0 follow-up). The visual card tile's edit controls were inside a `group-hover` overlay — unreachable on touch. Now, on touch only (`useIsTouch` → `(hover: none)`), tapping the always-on quantity badge reveals a slim bottom bar with full desktop parity (owned ✓ toggle, owned + qty steppers with tap-to-edit numbers, remove); it's a thin strip over a gradient, not the ~45% hover panel, and dismisses on tap-art / tap-outside / re-tap badge. The Commander crown becomes an always-visible corner tap on touch. Desktop/pointer behaviour is unchanged — everything new is gated behind `isTouch`. Pattern documented in `docs/ARCHITECTURE.md` → **Touch & Sizing System** (Grid tile editing).
+
+Prior: `v1.26.0` — Site-wide touch & sizing pass. One unified, finger-friendly scale across desktop and touch (no responsive split): 11px text floor, 44px standalone chrome buttons, dense inline controls un-gated from `opacity-0 group-hover` and always visible at ~28px, explicit `viewport-fit=cover`. Standard in `docs/ARCHITECTURE.md` → **Touch & Sizing System**.
 
 ## Post-Version Checklist
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,6 +47,7 @@ Living reference for file structure, state ownership, and key technical patterns
 | `useDeckManager.tsx` | `DeckProvider` + `useDeckManager` — all deck CRUD, commander ops, sideboard ops, sort state, thumbnail toggle, `lastAddedId`; persists to localStorage |
 | `useDeckImportExport.tsx` | File import parsing (`.txt` deck lists) and export formatting; owned by `page.tsx` |
 | `useDeckStats.ts` | Pure derived stats from `activeDeck` — `totalCards`, `totalValue`, `remainingCost`, `hasPriceData`, `targetDeckSize`, `isAtTarget`, `isOverTarget`, `buyOnTCGPlayer()`, `buyOnCardKingdom()` |
+| `useIsTouch.ts` | `useIsTouch()` — `matchMedia("(hover: none)")` listener; single source of truth for touch-only affordances (see Touch & Sizing System) |
 
 ### `src/lib/`
 
@@ -242,6 +243,10 @@ Unified, touch-first sizing applied across all surfaces (desktop included — on
 **Spacing.** Interactive rows: `py-1.5`+ and `gap-1.5`+ minimum. Reserve `py-0.5`/`gap-1` for non-interactive inline runs.
 
 **Viewport.** `layout.tsx` exports an explicit `viewport` with `viewportFit: "cover"` for iPad/notch safe areas (Next.js otherwise injects a default without it).
+
+**Touch detection.** `useIsTouch()` (`src/hooks/useIsTouch.ts`) is the single source of truth — a `matchMedia("(hover: none)")` listener. Use it to add touch-only affordances; never to remove pointer/hover behaviour.
+
+**Grid tile editing (`VisualCard`, deck mode).** The desktop edit surface is a `group-hover` slide-up overlay (name/type/steppers) — unreachable on touch and, if naively tap-revealed, it covers ~45% of the art. On touch (`useIsTouch`) the model is different: the always-on **qty badge is a reveal trigger** — tapping it opens a slim, full-width bottom bar with full desktop parity (owned ✓ toggle, owned & qty steppers with tap-to-edit numbers, remove). The bar is always mounted (visibility toggled via classes) so number inputs commit `onBlur`. It's dismissed by tapping the art, tapping outside the card (`pointerdown` listener gated on `barOpen`), or re-tapping the badge; the badge and price pill hide while it's open. The commander crown is un-gated to an always-visible corner tap rather than folded into the bar. Desktop hover is untouched — everything new is gated behind `isTouch`, and the badge's emulated-hover visuals are suppressed on touch (`badgeHoverActive = !isTouch && isCardHovered`).
 
 ### React Patterns
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -217,6 +217,32 @@ Any navigation action (tab click, deck name click, home button) **must** call `o
 
 **Depth model:** Warm Stone sidebar is RAISED (panel lighter than base); Zed Dark sidebar is RECESSED (panel darker than base) — same token names, theme handles the difference.
 
+### Touch & Sizing System
+
+<!-- Last updated: v1.26.0 -->
+
+Unified, touch-first sizing applied across all surfaces (desktop included — one comfortable scale, no responsive split). Established in v1.26.0 to kill ad-hoc per-component values. **When adding UI, conform to these floors instead of inventing new sizes.**
+
+**Text floor — nothing below 11px.**
+- Primary content & interactive labels: `text-sm` (14px)
+- Secondary / metadata: `text-xs` (12px)
+- Micro labels only (uppercase section headers, badges, counts): `text-[11px]`
+- Banned: `text-[8px]`, `text-[9px]`, `text-[10px]`. Promote to the role-appropriate floor above.
+
+**Icons.**
+- Functional icons (inside buttons, indicators): ≥ 16px (`w-4 h-4` / `size={16}`)
+- Standalone nav / action icons: 18–20px (`w-5 h-5`)
+- Decorative dots may stay small.
+
+**Tap targets (44px = iOS HIG / 48dp Android floor).**
+- Standalone chrome buttons (sidebar rail, toolbar, modal close, back, hamburger, home, settings): **44px** — `h-11 w-11` for icon buttons, `min-h-11` for text buttons.
+- Dense inline controls (table qty/owned steppers, card-overlay buttons, chips): **always visible** (≥ 28px, `w-7 h-7`) with real 16px lucide icons.
+- **Never gate an interactive control behind `opacity-0 group-hover:opacity-100`** — touch devices have no hover, so the control becomes unreachable. Use always-on (optionally `opacity-70 hover:opacity-100`).
+
+**Spacing.** Interactive rows: `py-1.5`+ and `gap-1.5`+ minimum. Reserve `py-0.5`/`gap-1` for non-interactive inline runs.
+
+**Viewport.** `layout.tsx` exports an explicit `viewport` with `viewportFit: "cover"` for iPad/notch safe areas (Next.js otherwise injects a default without it).
+
 ### React Patterns
 
 - `setCardRef(id)` — curried helper for card refs; inline `{ if(el) }` causes parse errors in JSX

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
 import { DeckProvider } from '@/hooks/useDeckManager';
@@ -8,6 +8,14 @@ const inter = Inter({ subsets: ['latin'] });
 export const metadata: Metadata = {
   title: 'Project Brew',
   description: 'Minimalist MTG Deck Builder',
+};
+
+// Explicit viewport so iPad/notched devices get safe-area insets (Next.js
+// otherwise injects a default without viewport-fit). See ARCHITECTURE.md.
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  viewportFit: 'cover',
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -430,7 +430,7 @@ export default function Dashboard() {
             <button
               onClick={() => setMobileSidebarOpen(true)}
               aria-label="Open menu"
-              className="w-9 h-9 flex items-center justify-center rounded-md text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
+              className="w-11 h-11 flex items-center justify-center rounded-md text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
             >
               <Menu className="w-5 h-5" />
             </button>

--- a/src/components/home/DeckCoverCard.tsx
+++ b/src/components/home/DeckCoverCard.tsx
@@ -27,10 +27,10 @@ export default function DeckCoverCard({ deck, onClick }: DeckCoverCardProps) {
     <div
       onClick={onClick}
       className="
-        w-[100px] h-[140px] rounded-lg cursor-pointer
+        w-[120px] h-[168px] rounded-lg cursor-pointer
         border border-line-default bg-surface-raised
         flex flex-col items-end justify-end
-        pb-2.5 gap-1
+        pb-3 gap-1
         relative overflow-hidden shrink-0
         hover:border-surface-hover transition-colors
       "
@@ -38,11 +38,11 @@ export default function DeckCoverCard({ deck, onClick }: DeckCoverCardProps) {
       {/* Placeholder art */}
       <div className={`absolute inset-0 bg-gradient-to-br ${tint} opacity-50`} />
       {/* Text — above gradient */}
-      <div className="relative z-10 flex flex-col items-center w-full gap-0.5 px-1.5">
-        <span className="text-[10px] font-medium text-content-heading text-center leading-tight line-clamp-2">
+      <div className="relative z-10 flex flex-col items-center w-full gap-0.5 px-2">
+        <span className="text-xs font-medium text-content-heading text-center leading-tight line-clamp-2">
           {deck.name || "Untitled"}
         </span>
-        <span className="text-[9px] text-content-muted">
+        <span className="text-[11px] text-content-muted">
           {deck.cards.reduce((sum, c) => sum + c.quantity, 0)} cards
         </span>
       </div>

--- a/src/components/home/GhostDeckCard.tsx
+++ b/src/components/home/GhostDeckCard.tsx
@@ -8,10 +8,10 @@ export default function GhostDeckCard({ onClick }: GhostDeckCardProps) {
   return (
     <div
       onClick={onClick}
-      className="w-[100px] h-[140px] rounded-lg cursor-pointer border border-dashed border-input-edge-focus flex flex-col items-center justify-center gap-1.5 opacity-50 hover:opacity-100 hover:bg-[color:var(--input-edge-focus)]/5 transition-opacity transition-colors text-[color:var(--input-edge-focus)] shrink-0"
+      className="w-[120px] h-[168px] rounded-lg cursor-pointer border border-dashed border-input-edge-focus flex flex-col items-center justify-center gap-1.5 opacity-50 hover:opacity-100 hover:bg-[color:var(--input-edge-focus)]/5 transition-opacity transition-colors text-[color:var(--input-edge-focus)] shrink-0"
     >
-      <Plus className="w-5 h-5" />
-      <span className="text-[10px] text-center leading-tight px-2">New Deck</span>
+      <Plus className="w-6 h-6" />
+      <span className="text-xs text-center leading-tight px-2">New Deck</span>
     </div>
   );
 }

--- a/src/components/home/HomeScreen.tsx
+++ b/src/components/home/HomeScreen.tsx
@@ -35,7 +35,7 @@ export default function HomeScreen({ decks, onDeckSelect, onCreateDeck }: HomeSc
         <h2 className="text-base font-medium text-content-heading">
           What are you brewing?
         </h2>
-        <p className="text-xs text-content-faint">{tagline}</p>
+        <p className="text-sm text-content-faint">{tagline}</p>
       </div>
 
       {/* Deck grid */}
@@ -51,8 +51,10 @@ export default function HomeScreen({ decks, onDeckSelect, onCreateDeck }: HomeSc
         {/* Ghost deck slot — always last */}
         <div ref={ghostRef} className="relative">
           <GhostDeckCard onClick={() => setPickerOpen(true)} />
+          {/* Picker drops below the ghost card, centered — avoids overflowing
+              the viewport on narrow/touch screens where left-full would clip. */}
           {pickerOpen && (
-            <div className="absolute left-full ml-2 top-0 w-52 bg-surface-base border border-line-default rounded-lg shadow-xl z-50">
+            <div className="absolute left-1/2 -translate-x-1/2 top-full mt-2 w-52 bg-surface-base border border-line-default rounded-lg shadow-xl z-50">
               <FormatPicker
                 onSelect={(format) => {
                   setPickerOpen(false);

--- a/src/components/layout/CategoryChips.tsx
+++ b/src/components/layout/CategoryChips.tsx
@@ -41,17 +41,17 @@ export default function CategoryChips({
 
   return (
     <div className="px-2.5 pt-2 pb-1 border-b border-line-subtle shrink-0">
-      <div className="text-[9px] text-content-faint uppercase tracking-wider mb-1.5">
+      <div className="text-[11px] text-content-faint uppercase tracking-wider mb-1.5">
         Quick Search
       </div>
-      <div className="flex flex-wrap gap-1.5">
+      <div className="flex flex-wrap gap-2">
         {visible.map((cat) => {
           const isActive = activeChipId === cat.id;
           return (
             <button
               key={cat.id}
               onClick={() => onSelectChip(cat.id, cat.query)}
-              className={`px-2 py-0.5 rounded text-[10px] border transition-colors ${
+              className={`px-2.5 py-1.5 rounded text-xs border transition-colors ${
                 isActive
                   ? "bg-blue-900/30 border-blue-500/30 text-blue-400"
                   : "bg-surface-raised border-line-default text-content-tertiary hover:text-content-heading hover:border-line-hover"

--- a/src/components/layout/FilterPanel.tsx
+++ b/src/components/layout/FilterPanel.tsx
@@ -147,7 +147,7 @@ function ToggleChip({
   return (
     <button
       onClick={onClick}
-      className={`flex items-center gap-1 px-2 py-0.5 rounded text-[10px] border transition-colors ${
+      className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs border transition-colors ${
         active
           ? activeClassName
           : "bg-surface-raised border-line-default text-content-muted"
@@ -211,10 +211,10 @@ export default function FilterPanel({ filters, onFiltersChange }: FilterPanelPro
       {/* Price Range */}
       <div>
         <div className="flex items-center justify-between mb-2">
-          <div className="text-[10px] text-content-muted uppercase tracking-wider">Price Range</div>
+          <div className="text-[11px] text-content-muted uppercase tracking-wider">Price Range</div>
           <button
             onClick={() => onFiltersChange({ ...filters, anyPrice: !filters.anyPrice })}
-            className={`text-[10px] px-1.5 py-0.5 rounded border transition-colors ${
+            className={`text-[11px] px-2 py-1 rounded border transition-colors ${
               filters.anyPrice
                 ? "bg-blue-900/30 border-blue-500/30 text-blue-400"
                 : "bg-surface-raised border-line-default text-content-muted hover:text-content-secondary"
@@ -237,12 +237,12 @@ export default function FilterPanel({ filters, onFiltersChange }: FilterPanelPro
                 setLocalMin(String(val));
                 onFiltersChange({ ...filters, priceMin: val });
               }}
-              className="w-10 bg-input-surface border border-input-edge rounded text-xs text-content-secondary px-1.5 py-0.5 text-center focus:outline-none focus:border-neutral-500"
+              className="w-12 bg-input-surface border border-input-edge rounded text-sm text-content-secondary px-2 py-1.5 text-center focus:outline-none focus:border-neutral-500"
             />
           </div>
           <div
             ref={sliderRef}
-            className="flex-1 relative h-2 bg-surface-overlay rounded cursor-pointer"
+            className="flex-1 relative h-2.5 bg-surface-overlay rounded cursor-pointer"
             onMouseDown={handleSliderMouseDown}
           >
             {(() => {
@@ -257,7 +257,7 @@ export default function FilterPanel({ filters, onFiltersChange }: FilterPanelPro
                     }}
                   />
                   <div
-                    className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 bg-white rounded-full border-2 border-blue-500 shadow"
+                    className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-4 h-4 bg-white rounded-full border-2 border-blue-500 shadow"
                     style={{ left: `${(displayMax / 100) * 100}%`, cursor: dragMax !== null ? "grabbing" : "grab" }}
                   />
                 </>
@@ -277,7 +277,7 @@ export default function FilterPanel({ filters, onFiltersChange }: FilterPanelPro
                 setLocalMax(String(val));
                 onFiltersChange({ ...filters, priceMax: val });
               }}
-              className="w-10 bg-input-surface border border-input-edge rounded text-xs text-content-secondary px-1.5 py-0.5 text-center focus:outline-none focus:border-neutral-500"
+              className="w-12 bg-input-surface border border-input-edge rounded text-sm text-content-secondary px-2 py-1.5 text-center focus:outline-none focus:border-neutral-500"
             />
           </div>
         </div>
@@ -286,7 +286,7 @@ export default function FilterPanel({ filters, onFiltersChange }: FilterPanelPro
       {/* Release Year */}
       <div>
         <div className="mb-2">
-          <div className="text-[10px] text-content-muted uppercase tracking-wider mb-1.5">Release Year</div>
+          <div className="text-[11px] text-content-muted uppercase tracking-wider mb-1.5">Release Year</div>
           <div className="flex gap-1">
             {([
               { label: "This Year", min: CURRENT_YEAR, max: CURRENT_YEAR },
@@ -298,7 +298,7 @@ export default function FilterPanel({ filters, onFiltersChange }: FilterPanelPro
                 <button
                   key={preset.label}
                   onClick={() => onFiltersChange({ ...filters, yearMin: preset.min, yearMax: preset.max })}
-                  className={`flex-1 px-1.5 py-0.5 rounded text-[10px] border transition-colors ${
+                  className={`flex-1 px-2 py-1.5 rounded text-xs border transition-colors ${
                     active
                       ? "bg-blue-900/30 border-blue-500/30 text-blue-400"
                       : "bg-surface-raised border-line-default text-content-muted hover:text-content-secondary"
@@ -322,7 +322,7 @@ export default function FilterPanel({ filters, onFiltersChange }: FilterPanelPro
               setLocalYearMin(String(val));
               onFiltersChange({ ...filters, yearMin: val });
             }}
-            className="w-14 bg-input-surface border border-input-edge rounded text-xs text-content-secondary px-1.5 py-0.5 text-center focus:outline-none focus:border-neutral-500"
+            className="w-16 bg-input-surface border border-input-edge rounded text-sm text-content-secondary px-2 py-1.5 text-center focus:outline-none focus:border-neutral-500"
           />
           <span className="text-xs text-content-muted">to</span>
           <input
@@ -336,7 +336,7 @@ export default function FilterPanel({ filters, onFiltersChange }: FilterPanelPro
               setLocalYearMax(String(val));
               onFiltersChange({ ...filters, yearMax: val });
             }}
-            className="w-14 bg-input-surface border border-input-edge rounded text-xs text-content-secondary px-1.5 py-0.5 text-center focus:outline-none focus:border-neutral-500"
+            className="w-16 bg-input-surface border border-input-edge rounded text-sm text-content-secondary px-2 py-1.5 text-center focus:outline-none focus:border-neutral-500"
           />
         </div>
       </div>
@@ -344,7 +344,7 @@ export default function FilterPanel({ filters, onFiltersChange }: FilterPanelPro
       {/* Rarity */}
       <div>
         <div className="flex items-center justify-between mb-2">
-          <div className="text-[10px] text-content-muted uppercase tracking-wider">Rarity</div>
+          <div className="text-[11px] text-content-muted uppercase tracking-wider">Rarity</div>
           <button
             onClick={() =>
               onFiltersChange({
@@ -352,7 +352,7 @@ export default function FilterPanel({ filters, onFiltersChange }: FilterPanelPro
                 rarities: filters.rarities.size === RARITIES.length ? new Set() : new Set(RARITIES),
               })
             }
-            className="text-[10px] text-content-muted hover:text-content-secondary transition-colors"
+            className="text-[11px] px-1.5 py-1 text-content-muted hover:text-content-secondary transition-colors"
           >
             {filters.rarities.size === RARITIES.length ? "None" : "All"}
           </button>
@@ -375,7 +375,7 @@ export default function FilterPanel({ filters, onFiltersChange }: FilterPanelPro
       {/* Card Type */}
       <div>
         <div className="flex items-center justify-between mb-2">
-          <div className="text-[10px] text-content-muted uppercase tracking-wider">Card Type</div>
+          <div className="text-[11px] text-content-muted uppercase tracking-wider">Card Type</div>
           <button
             onClick={() =>
               onFiltersChange({
@@ -383,7 +383,7 @@ export default function FilterPanel({ filters, onFiltersChange }: FilterPanelPro
                 types: filters.types.size === TYPES.length ? new Set() : new Set(TYPES),
               })
             }
-            className="text-[10px] text-content-muted hover:text-content-secondary transition-colors"
+            className="text-[11px] px-1.5 py-1 text-content-muted hover:text-content-secondary transition-colors"
           >
             {filters.types.size === TYPES.length ? "None" : "All"}
           </button>
@@ -406,7 +406,7 @@ export default function FilterPanel({ filters, onFiltersChange }: FilterPanelPro
       {/* Colors */}
       <div>
         <div className="flex items-center justify-between mb-2">
-          <div className="text-[10px] text-content-muted uppercase tracking-wider">Colors</div>
+          <div className="text-[11px] text-content-muted uppercase tracking-wider">Colors</div>
           <button
             onClick={() =>
               onFiltersChange({
@@ -414,7 +414,7 @@ export default function FilterPanel({ filters, onFiltersChange }: FilterPanelPro
                 colors: filters.colors.size === COLORS.length ? new Set() : new Set(COLORS.map((c) => c.key)),
               })
             }
-            className="text-[10px] text-content-muted hover:text-content-secondary transition-colors"
+            className="text-[11px] px-1.5 py-1 text-content-muted hover:text-content-secondary transition-colors"
           >
             {filters.colors.size === COLORS.length ? "None" : "All"}
           </button>
@@ -431,7 +431,7 @@ export default function FilterPanel({ filters, onFiltersChange }: FilterPanelPro
             >
               <img
                 src={`https://svgs.scryfall.io/card-symbols/${key}.svg`}
-                className="w-3 h-3"
+                className="w-4 h-4"
                 alt={key}
               />
               {label}
@@ -444,7 +444,7 @@ export default function FilterPanel({ filters, onFiltersChange }: FilterPanelPro
         <div className="pt-1">
           <button
             onClick={() => onFiltersChange(DEFAULT_FILTERS)}
-            className="w-full px-2 py-1 rounded text-[10px] border border-line-default bg-surface-raised text-content-muted hover:text-content-secondary hover:border-line-hover transition-colors"
+            className="w-full px-2 py-2 rounded text-xs border border-line-default bg-surface-raised text-content-muted hover:text-content-secondary hover:border-line-hover transition-colors"
           >
             Reset to defaults
           </button>

--- a/src/components/layout/FormatPicker.tsx
+++ b/src/components/layout/FormatPicker.tsx
@@ -16,19 +16,19 @@ export function FormatPicker({ onSelect, currentFormat }: FormatPickerProps) {
   }[] = [
     {
       value: "freeform",
-      icon: <span className="text-[9px] font-bold text-content-muted bg-neutral-500/10 px-0.5 rounded leading-none">FF</span>,
+      icon: <span className="text-[11px] font-bold text-content-muted bg-neutral-500/10 px-1 rounded leading-none">FF</span>,
       label: "Freeform",
       description: "No rules. Build anything.",
     },
     {
       value: "standard",
-      icon: <span className="text-[9px] font-bold text-blue-400 bg-blue-400/10 px-0.5 rounded leading-none">STD</span>,
+      icon: <span className="text-[11px] font-bold text-blue-400 bg-blue-400/10 px-1 rounded leading-none">STD</span>,
       label: "Standard",
       description: "60 cards · 4-copy limit · 15-card sideboard",
     },
     {
       value: "commander",
-      icon: <span className="text-[9px] font-bold text-yellow-400 bg-yellow-400/10 px-0.5 rounded leading-none">CMD</span>,
+      icon: <span className="text-[11px] font-bold text-yellow-400 bg-yellow-400/10 px-1 rounded leading-none">CMD</span>,
       label: "Commander",
       description: "100 cards · Singleton · Commander + color identity",
     },
@@ -36,23 +36,23 @@ export function FormatPicker({ onSelect, currentFormat }: FormatPickerProps) {
 
   return (
     <div className="py-1">
-      <div className="px-3 py-1.5 text-[9px] font-bold text-content-muted uppercase tracking-widest">
+      <div className="px-3 py-1.5 text-[11px] font-bold text-content-muted uppercase tracking-widest">
         Choose Format
       </div>
       {formats.map(({ value, icon, label, description }) => (
         <button
           key={value}
           onClick={() => onSelect(value)}
-          className={`w-full flex items-center gap-2.5 px-3 py-2.5 hover:bg-surface-raised cursor-pointer transition-colors text-left ${
+          className={`w-full flex items-center gap-2.5 px-3 py-3 hover:bg-surface-raised cursor-pointer transition-colors text-left ${
             currentFormat === value ? "bg-neutral-800/50" : ""
           }`}
         >
-          <span className="flex items-center justify-center w-6 shrink-0">
+          <span className="flex items-center justify-center w-7 shrink-0">
             {icon}
           </span>
           <span className="flex flex-col gap-0.5">
-            <span className="text-xs font-medium text-content-heading">{label}</span>
-            <span className="text-[10px] text-content-muted">{description}</span>
+            <span className="text-sm font-medium text-content-heading">{label}</span>
+            <span className="text-xs text-content-muted">{description}</span>
           </span>
         </button>
       ))}

--- a/src/components/layout/SampleHandModal.tsx
+++ b/src/components/layout/SampleHandModal.tsx
@@ -192,7 +192,7 @@ export default function SampleHandModal({
               <h2 className="text-lg md:text-xl font-bold text-content-primary">
                 Opening Hand Simulator
               </h2>
-              <p className="text-content-muted text-[10px] md:text-xs uppercase tracking-widest font-bold">
+              <p className="text-content-muted text-[11px] md:text-xs uppercase tracking-widest font-bold">
                 Hand: {hand.length} · Library: {library.length} · Mulligans: {mulliganCount}
               </p>
             </div>
@@ -213,7 +213,8 @@ export default function SampleHandModal({
             </button>
             <button
               onClick={onClose}
-              className="p-2 bg-surface-base border border-line-subtle rounded-full text-content-tertiary hover:text-content-primary transition-all hover:bg-surface-raised shadow-sm"
+              aria-label="Close simulator"
+              className="w-11 h-11 flex items-center justify-center bg-surface-base border border-line-subtle rounded-full text-content-tertiary hover:text-content-primary transition-all hover:bg-surface-raised shadow-sm"
             >
               <X className="w-5 h-5" />
             </button>
@@ -227,7 +228,7 @@ export default function SampleHandModal({
 
               {/* Section 1 — Mana Curve */}
               <section>
-                <h4 className="text-[10px] font-bold text-content-muted uppercase tracking-widest mb-3">
+                <h4 className="text-[11px] font-bold text-content-muted uppercase tracking-widest mb-3">
                   Mana Curve
                 </h4>
                 {/* Histogram bars */}
@@ -241,7 +242,7 @@ export default function SampleHandModal({
                         key={cmc}
                         className="flex-1 flex flex-col items-center justify-end h-full gap-0.5"
                       >
-                        <span className="text-[9px] text-content-tertiary font-bold leading-none">
+                        <span className="text-[11px] text-content-tertiary font-bold leading-none">
                           {count > 0 ? count : ""}
                         </span>
                         <div
@@ -259,7 +260,7 @@ export default function SampleHandModal({
                 <div className="flex gap-1 mb-3">
                   {[1, 2, 3, 4, 5, 6, 7].map((cmc) => (
                     <div key={cmc} className="flex-1 text-center">
-                      <span className="text-[9px] text-content-faint font-bold">
+                      <span className="text-[11px] text-content-faint font-bold">
                         {cmc === 7 ? "7+" : cmc}
                       </span>
                     </div>
@@ -280,7 +281,7 @@ export default function SampleHandModal({
 
               {/* Section 2 — Current Hand */}
               <section>
-                <h4 className="text-[10px] font-bold text-content-muted uppercase tracking-widest mb-3">
+                <h4 className="text-[11px] font-bold text-content-muted uppercase tracking-widest mb-3">
                   Current Hand
                 </h4>
                 <div className="space-y-2.5">
@@ -304,12 +305,12 @@ export default function SampleHandModal({
               {/* Section 3 — Draw Odds */}
               <section>
                 <div className="flex items-center justify-between mb-3">
-                  <h4 className="text-[10px] font-bold text-content-muted uppercase tracking-widest">
+                  <h4 className="text-[11px] font-bold text-content-muted uppercase tracking-widest">
                     Draw Odds
                   </h4>
                   <button
                     onClick={() => setShowLands((prev) => !prev)}
-                    className={`text-[9px] font-bold uppercase tracking-widest px-2 py-0.5 rounded border transition-colors ${
+                    className={`text-[11px] font-bold uppercase tracking-widest px-2.5 py-1 rounded border transition-colors ${
                       showLands
                         ? "bg-emerald-500/15 border-emerald-500/40 text-emerald-400"
                         : "bg-surface-raised border-line-default text-content-muted hover:text-content-tertiary"
@@ -345,7 +346,7 @@ export default function SampleHandModal({
                         >
                           {card.name}
                         </span>
-                        <span className="text-[10px] text-content-faint shrink-0 ml-1">
+                        <span className="text-[11px] text-content-faint shrink-0 ml-1">
                           ×{copiesInLibrary}
                         </span>
                         <span
@@ -399,7 +400,7 @@ export default function SampleHandModal({
                         </div>
                       )}
                     </div>
-                    <p className="mt-2 text-[9px] text-content-muted font-bold truncate text-center uppercase tracking-tight">
+                    <p className="mt-2 text-[11px] text-content-muted font-bold truncate text-center uppercase tracking-tight">
                       {card.name}
                     </p>
                   </div>
@@ -415,7 +416,7 @@ export default function SampleHandModal({
                   </p>
                   <button
                     onClick={shuffleAndDraw}
-                    className="mt-4 px-6 py-2 bg-surface-raised hover:bg-surface-overlay text-content-primary rounded-lg text-xs font-bold uppercase tracking-widest transition-colors"
+                    className="mt-4 px-6 py-2.5 min-h-11 bg-surface-raised hover:bg-surface-overlay text-content-primary rounded-lg text-xs font-bold uppercase tracking-widest transition-colors"
                   >
                     Reshuffle
                   </button>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -83,25 +83,26 @@ export default function Sidebar({ onImport, onExport, isImporting, onOpenSetting
         <div className="flex flex-col h-full min-w-0">
           {/* Tab bar — Decks only */}
           <div className="flex items-center shrink-0">
-            <div className="flex items-center gap-1.5 flex-1 justify-center px-3 py-2.5 text-xs font-medium border-b border-transparent bg-surface-panel text-content-primary">
-              <Layers className="w-3.5 h-3.5" />
+            <div className="flex items-center gap-2 flex-1 justify-center px-3 py-3 text-sm font-medium border-b border-transparent bg-surface-panel text-content-primary">
+              <Layers className="w-4 h-4" />
               Decks
             </div>
             {isDesktop && (
               <button
                 onClick={handleCollapse}
-                className="px-2.5 py-2.5 bg-surface-deep border-b border-line-subtle text-content-muted hover:text-content-primary transition-colors shrink-0"
+                aria-label="Collapse sidebar"
+                className="w-11 h-11 flex items-center justify-center bg-surface-deep border-b border-line-subtle text-content-muted hover:text-content-primary transition-colors shrink-0"
               >
-                <PanelRightOpen className="w-4 h-4" />
+                <PanelRightOpen className="w-5 h-5" />
               </button>
             )}
             {!isDesktop && (
               <button
                 onClick={onMobileClose}
                 aria-label="Close menu"
-                className="w-9 h-9 flex items-center justify-center bg-surface-deep border-b border-line-subtle text-content-muted hover:text-content-primary transition-colors"
+                className="w-11 h-11 flex items-center justify-center bg-surface-deep border-b border-line-subtle text-content-muted hover:text-content-primary transition-colors"
               >
-                <PanelLeftClose className="w-4 h-4" />
+                <PanelLeftClose className="w-5 h-5" />
               </button>
             )}
           </div>
@@ -117,33 +118,35 @@ export default function Sidebar({ onImport, onExport, isImporting, onOpenSetting
           </div>
 
           <div className="mt-auto border-t border-line-subtle shrink-0">
-            <div className="flex items-center gap-2 px-3 py-2">
+            <div className="flex items-center gap-2 px-2 py-1.5">
               <button
                 onClick={isOnHomeScreen ? undefined : onGoHome}
                 className={`
-                  w-7 h-7 rounded-md flex items-center justify-center transition-colors
+                  w-11 h-11 rounded-md flex items-center justify-center transition-colors
                   ${isOnHomeScreen
                     ? "text-content-disabled cursor-default"
                     : "text-content-muted hover:text-content-primary hover:bg-surface-raised"
                   }
                 `}
                 title="Home"
+                aria-label="Home"
               >
-                <Home className="w-3.5 h-3.5" />
+                <Home className="w-5 h-5" />
               </button>
               <button
                 onClick={() => onOpenSettings("whatsnew")}
-                className="flex items-center gap-1.5 px-2 py-0.5 border rounded-full text-[9px] font-bold uppercase tracking-wider transition-colors bg-blue-500/10 border-blue-500/20 text-blue-400 hover:bg-blue-500/20"
+                className="flex items-center gap-1.5 px-2.5 py-1 border rounded-full text-[11px] font-bold uppercase tracking-wider transition-colors bg-blue-500/10 border-blue-500/20 text-blue-400 hover:bg-blue-500/20"
               >
                 v{APP_VERSION}
               </button>
               {!isDesktop && (
                 <button
                   onClick={() => onOpenSettings("preferences")}
-                  className="ml-auto w-7 h-7 rounded-md flex items-center justify-center text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
+                  className="ml-auto w-11 h-11 rounded-md flex items-center justify-center text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
                   title="Settings"
+                  aria-label="Settings"
                 >
-                  <Settings className="w-3.5 h-3.5" />
+                  <Settings className="w-5 h-5" />
                 </button>
               )}
             </div>

--- a/src/components/layout/SidebarDecksTab.tsx
+++ b/src/components/layout/SidebarDecksTab.tsx
@@ -134,7 +134,7 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
           return (
             <div
               key={deck.id}
-              className={`flex items-center gap-1.5 px-2 py-1.5 rounded-lg group relative ${
+              className={`flex items-center gap-2 px-2 py-2.5 rounded-lg group relative ${
                 isActive ? "bg-surface-panel" : "hover:bg-neutral-800/50"
               } transition-colors`}
             >
@@ -157,7 +157,7 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
                   onCloseSettings?.();
                   onNavigate?.();
                 }}
-                className={`flex-1 text-left text-xs truncate transition-colors min-w-0 ${
+                className={`flex-1 text-left text-sm truncate transition-colors min-w-0 ${
                   isActive ? "text-content-primary" : "text-content-tertiary hover:text-content-primary"
                 }`}
               >
@@ -167,7 +167,7 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
               </button>
 
               {/* Card count */}
-              <span className="text-[10px] text-content-faint shrink-0">{cardCount}</span>
+              <span className="text-[11px] text-content-faint shrink-0">{cardCount}</span>
 
               {/* Format badge — clickable, opens format picker */}
               <div className="shrink-0">
@@ -181,17 +181,17 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
                   className="flex items-center"
                 >
                   {deck.format === "standard" && (
-                    <span className="text-[9px] font-bold text-blue-400 bg-blue-400/10 px-1 rounded hover:bg-blue-400/20 transition-colors cursor-pointer">
+                    <span className="text-[11px] font-bold text-blue-400 bg-blue-400/10 px-1.5 py-0.5 rounded hover:bg-blue-400/20 transition-colors cursor-pointer">
                       STD
                     </span>
                   )}
                   {deck.format === "commander" && (
-                    <span className="text-[9px] font-bold text-yellow-400 bg-yellow-400/10 px-1 rounded hover:bg-yellow-400/20 transition-colors cursor-pointer">
+                    <span className="text-[11px] font-bold text-yellow-400 bg-yellow-400/10 px-1.5 py-0.5 rounded hover:bg-yellow-400/20 transition-colors cursor-pointer">
                       CMD
                     </span>
                   )}
                   {(!deck.format || deck.format === "freeform") && (
-                    <span className="text-[9px] font-bold text-neutral-500 bg-neutral-500/10 px-1 rounded hover:bg-neutral-500/20 transition-colors cursor-pointer">
+                    <span className="text-[11px] font-bold text-neutral-500 bg-neutral-500/10 px-1.5 py-0.5 rounded hover:bg-neutral-500/20 transition-colors cursor-pointer">
                       FF
                     </span>
                   )}
@@ -227,7 +227,7 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
                     ? "View sideboard"
                     : "Add sideboard"
                 }
-                className={`w-6 h-6 rounded-full flex items-center justify-center shrink-0 transition-colors ${
+                className={`w-7 h-7 rounded-full flex items-center justify-center shrink-0 transition-colors ${
                   isCommander
                     ? "text-content-faint cursor-not-allowed opacity-40"
                     : hasSideboard
@@ -235,7 +235,7 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
                     : "text-content-disabled hover:text-content-tertiary"
                 }`}
               >
-                <Layers className="w-3 h-3" />
+                <Layers className="w-4 h-4" />
               </button>
 
               {/* × button — hover-only, opens delete dropdown */}
@@ -246,9 +246,10 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
                       openDeleteDropdownId === deck.id ? null : deck.id
                     )
                   }
-                  className="w-6 h-6 rounded-full flex items-center justify-center text-content-disabled hover:text-content-tertiary opacity-0 group-hover:opacity-100 transition-all"
+                  aria-label="Delete deck"
+                  className="w-7 h-7 rounded-full flex items-center justify-center text-content-disabled hover:text-content-tertiary opacity-60 group-hover:opacity-100 transition-all"
                 >
-                  <X className="w-3 h-3" />
+                  <X className="w-4 h-4" />
                 </button>
 
                 {openDeleteDropdownId === deck.id && (
@@ -261,7 +262,7 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
                         deleteDeck(deck.id);
                         setOpenDeleteDropdownId(null);
                       }}
-                      className="flex items-center gap-2 w-full text-left px-3 py-2 text-xs text-red-500 hover:bg-red-500/10 transition-colors"
+                      className="flex items-center gap-2 w-full text-left px-3 py-2.5 text-sm text-red-500 hover:bg-red-500/10 transition-colors"
                     >
                       Delete Deck
                     </button>
@@ -271,7 +272,7 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
                           deleteSideboard(deck.id);
                           setOpenDeleteDropdownId(null);
                         }}
-                        className="flex items-center gap-2 w-full text-left px-3 py-2 text-xs text-red-500 hover:bg-red-500/10 transition-colors"
+                        className="flex items-center gap-2 w-full text-left px-3 py-2.5 text-sm text-red-500 hover:bg-red-500/10 transition-colors"
                       >
                         Delete Sideboard
                       </button>
@@ -292,10 +293,10 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
               setNewDeckPickerDir(dir);
               setNewDeckPickerOpen(!newDeckPickerOpen);
             }}
-            className="mx-2 my-1 border border-dashed border-line-default rounded-md flex items-center justify-center gap-1.5 py-1.5 cursor-pointer text-content-faint hover:border-input-edge-focus hover:text-content-muted transition-colors"
+            className="mx-2 my-1 border border-dashed border-line-default rounded-md flex items-center justify-center gap-1.5 py-2.5 cursor-pointer text-content-faint hover:border-input-edge-focus hover:text-content-muted transition-colors"
           >
-            <Plus className="w-3 h-3" />
-            <span className="text-[10px]">New Deck</span>
+            <Plus className="w-4 h-4" />
+            <span className="text-xs">New Deck</span>
           </div>
           {newDeckPickerOpen && (
             <div
@@ -319,20 +320,20 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
         <div className="flex items-center gap-1.5">
           <button
             onClick={onExport}
-            className="flex items-center gap-1.5 flex-1 justify-center px-2 py-1.5 bg-surface-raised hover:bg-surface-overlay rounded-lg text-xs text-content-secondary hover:text-content-primary transition-colors"
+            className="flex items-center gap-1.5 flex-1 justify-center px-2 py-2.5 min-h-11 bg-surface-raised hover:bg-surface-overlay rounded-lg text-xs text-content-secondary hover:text-content-primary transition-colors"
           >
-            <Download className="w-3 h-3" />
+            <Download className="w-4 h-4" />
             Export
           </button>
           <button
             onClick={onImport}
             disabled={isImporting}
-            className="flex items-center gap-1.5 flex-1 justify-center px-2 py-1.5 bg-surface-raised hover:bg-surface-overlay rounded-lg text-xs text-content-secondary hover:text-content-primary transition-colors disabled:opacity-50"
+            className="flex items-center gap-1.5 flex-1 justify-center px-2 py-2.5 min-h-11 bg-surface-raised hover:bg-surface-overlay rounded-lg text-xs text-content-secondary hover:text-content-primary transition-colors disabled:opacity-50"
           >
             {isImporting ? (
-              <RefreshCw className="w-3 h-3 animate-spin" />
+              <RefreshCw className="w-4 h-4 animate-spin" />
             ) : (
-              <Upload className="w-3 h-3" />
+              <Upload className="w-4 h-4" />
             )}
             Import
           </button>
@@ -340,16 +341,16 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
         <div className="flex items-center gap-1.5">
           <button
             onClick={buyOnTCGPlayer}
-            className="flex items-center gap-1.5 flex-1 justify-center px-2 py-1.5 bg-orange-600/10 border border-orange-600/30 rounded-lg text-[10px] font-bold text-orange-400 hover:bg-orange-600/20 transition-colors"
+            className="flex items-center gap-1.5 flex-1 justify-center px-2 py-2.5 min-h-11 bg-orange-600/10 border border-orange-600/30 rounded-lg text-xs font-bold text-orange-400 hover:bg-orange-600/20 transition-colors"
           >
-            <ShoppingCart className="w-3 h-3" />
+            <ShoppingCart className="w-4 h-4" />
             TCGPlayer
           </button>
           <button
             onClick={buyOnCardKingdom}
-            className="flex items-center gap-1.5 flex-1 justify-center px-2 py-1.5 bg-blue-600/10 border border-blue-600/30 rounded-lg text-[10px] font-bold text-blue-400 hover:bg-blue-600/20 transition-colors"
+            className="flex items-center gap-1.5 flex-1 justify-center px-2 py-2.5 min-h-11 bg-blue-600/10 border border-blue-600/30 rounded-lg text-xs font-bold text-blue-400 hover:bg-blue-600/20 transition-colors"
           >
-            <ShoppingCart className="w-3 h-3" />
+            <ShoppingCart className="w-4 h-4" />
             Card Kingdom
           </button>
         </div>
@@ -382,7 +383,7 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
                   setDeckFormat(confirmDialog.deckId, "commander");
                   setConfirmDialog(null);
                 }}
-                className="w-full px-3 py-2 rounded-lg text-xs font-medium bg-yellow-600 hover:bg-yellow-500 text-content-primary transition-colors"
+                className="w-full px-3 py-2.5 min-h-11 rounded-lg text-sm font-medium bg-yellow-600 hover:bg-yellow-500 text-content-primary transition-colors"
               >
                 Merge into Main Deck
               </button>
@@ -392,7 +393,7 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
                   setDeckFormat(confirmDialog.deckId, "commander");
                   setConfirmDialog(null);
                 }}
-                className="w-full px-3 py-2 rounded-lg text-xs font-medium bg-red-600/20 text-red-400 border border-red-600/30 hover:bg-red-600/30 transition-colors"
+                className="w-full px-3 py-2.5 min-h-11 rounded-lg text-sm font-medium bg-red-600/20 text-red-400 border border-red-600/30 hover:bg-red-600/30 transition-colors"
               >
                 Delete Sideboard
               </button>

--- a/src/components/layout/SidebarRail.tsx
+++ b/src/components/layout/SidebarRail.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 function RailTooltip({ label }: { label: string }) {
   return (
-    <span className="absolute left-full ml-2 top-1/2 -translate-y-1/2 px-2 py-1 bg-surface-raised border border-line-default text-content-heading text-[10px] font-medium rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50">
+    <span className="absolute left-full ml-2 top-1/2 -translate-y-1/2 px-2 py-1 bg-surface-raised border border-line-default text-content-heading text-[11px] font-medium rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50">
       {label}
     </span>
   );
@@ -70,9 +70,9 @@ export default function SidebarRail({ expandTo, onOpenSettings, onGoHome, isOnHo
       <div className="group relative flex items-center">
         <button
           onClick={(e) => { e.stopPropagation(); expandTo(); }}
-          className="w-9 h-9 rounded-full flex items-center justify-center text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
+          className="w-11 h-11 rounded-full flex items-center justify-center text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
         >
-          <PanelLeftOpen className="w-4 h-4" />
+          <PanelLeftOpen className="w-5 h-5" />
         </button>
         <RailTooltip label="Expand Sidebar" />
       </div>
@@ -81,9 +81,9 @@ export default function SidebarRail({ expandTo, onOpenSettings, onGoHome, isOnHo
       <div className="group relative flex items-center">
         <button
           onClick={(e) => { e.stopPropagation(); expandTo(); }}
-          className="w-9 h-9 rounded-full flex items-center justify-center text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
+          className="w-11 h-11 rounded-full flex items-center justify-center text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
         >
-          <Layers className="w-4 h-4" />
+          <Layers className="w-5 h-5" />
         </button>
         <RailTooltip label="Decks" />
       </div>
@@ -92,9 +92,9 @@ export default function SidebarRail({ expandTo, onOpenSettings, onGoHome, isOnHo
       <div className="group relative flex items-center">
         <button
           onClick={handleNewDeck}
-          className="w-9 h-9 rounded-full flex items-center justify-center text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
+          className="w-11 h-11 rounded-full flex items-center justify-center text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
         >
-          <Plus className="w-4 h-4" />
+          <Plus className="w-5 h-5" />
         </button>
         {!railPickerOpen && <RailTooltip label="New Deck" />}
         {railPickerOpen && (
@@ -116,9 +116,9 @@ export default function SidebarRail({ expandTo, onOpenSettings, onGoHome, isOnHo
           target="_blank"
           rel="noopener noreferrer"
           onClick={(e) => e.stopPropagation()}
-          className="w-9 h-9 rounded-full flex items-center justify-center text-content-muted hover:text-yellow-400 transition-colors"
+          className="w-11 h-11 rounded-full flex items-center justify-center text-content-muted hover:text-yellow-400 transition-colors"
         >
-          <Coffee className="w-4 h-4" />
+          <Coffee className="w-5 h-5" />
         </a>
         <RailTooltip label="Buy Me a Coffee" />
       </div>
@@ -127,9 +127,9 @@ export default function SidebarRail({ expandTo, onOpenSettings, onGoHome, isOnHo
       <div className="group relative flex items-center">
         <button
           onClick={(e) => { e.stopPropagation(); onOpenSettings("preferences"); }}
-          className="w-9 h-9 rounded-full flex items-center justify-center text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
+          className="w-11 h-11 rounded-full flex items-center justify-center text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
         >
-          <Settings className="w-4 h-4" />
+          <Settings className="w-5 h-5" />
         </button>
         <RailTooltip label="Settings" />
       </div>
@@ -139,14 +139,14 @@ export default function SidebarRail({ expandTo, onOpenSettings, onGoHome, isOnHo
         <button
           onClick={isOnHomeScreen ? undefined : (e) => { e.stopPropagation(); onGoHome(); }}
           className={`
-            w-9 h-9 rounded-full flex items-center justify-center transition-colors
+            w-11 h-11 rounded-full flex items-center justify-center transition-colors
             ${isOnHomeScreen
               ? "text-content-disabled cursor-not-allowed"
               : "text-content-muted hover:text-content-primary hover:bg-surface-raised"
             }
           `}
         >
-          <Home className="w-4 h-4" />
+          <Home className="w-5 h-5" />
         </button>
         {!isOnHomeScreen && <RailTooltip label="Home" />}
       </div>

--- a/src/components/workspace/DeckToolsSheet.tsx
+++ b/src/components/workspace/DeckToolsSheet.tsx
@@ -58,7 +58,7 @@ function SegButton({
     <button
       onClick={onClick}
       disabled={disabled}
-      className={`flex-1 h-10 px-2 flex items-center justify-center gap-1.5 text-sm rounded-md transition-all ${
+      className={`flex-1 h-11 px-2 flex items-center justify-center gap-1.5 text-sm rounded-md transition-all ${
         active
           ? "bg-blue-600 text-white border border-blue-500/50"
           : disabled
@@ -74,7 +74,7 @@ function SegButton({
 function Section({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="space-y-2">
-      <span className="text-[10px] font-bold text-content-muted uppercase tracking-widest">
+      <span className="text-[11px] font-bold text-content-muted uppercase tracking-widest">
         {label}
       </span>
       {children}
@@ -136,7 +136,7 @@ export default function DeckToolsSheet({
           <button
             onClick={onClose}
             aria-label="Close deck tools"
-            className="w-9 h-9 -mr-2 flex items-center justify-center text-content-muted hover:text-content-primary transition-colors"
+            className="w-11 h-11 -mr-2 flex items-center justify-center text-content-muted hover:text-content-primary transition-colors"
           >
             <X className="w-5 h-5" />
           </button>
@@ -189,7 +189,7 @@ export default function DeckToolsSheet({
             <button
               onClick={() => setSortDir(sortDir === "asc" ? "desc" : "asc")}
               disabled={sortBy === "original"}
-              className={`w-full h-10 flex items-center justify-center gap-2 rounded-lg border text-sm transition-colors ${
+              className={`w-full h-11 flex items-center justify-center gap-2 rounded-lg border text-sm transition-colors ${
                 sortBy === "original"
                   ? "text-content-disabled border-line-subtle cursor-not-allowed"
                   : "text-content-secondary border-line-subtle hover:bg-surface-raised"

--- a/src/components/workspace/FindByNameBar.tsx
+++ b/src/components/workspace/FindByNameBar.tsx
@@ -7,6 +7,7 @@ import { useDeckManager } from "@/hooks/useDeckManager";
 import { parseDroppedText } from "@/hooks/useDeckImportExport";
 import { ScryfallCard, DeckCard } from "@/types";
 import { getFormatRules } from "@/lib/formatRules";
+import { useIsTouch } from "@/hooks/useIsTouch";
 
 interface FindByNameBarProps {
   showToast: (msg: string) => void;
@@ -98,15 +99,7 @@ export default function FindByNameBar({ showToast, registerFocusFn, registerSear
   // Touch devices have no hover, so the per-tile action overlay (Add / Flip /
   // Swap art) can't be reached the desktop way. On these we reveal the overlay
   // on the selected tile instead — tap a printing to select it, then tap Add.
-  const [isTouch, setIsTouch] = useState(false);
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return;
-    const mq = window.matchMedia("(hover: none)");
-    const update = () => setIsTouch(mq.matches);
-    update();
-    mq.addEventListener?.("change", update);
-    return () => mq.removeEventListener?.("change", update);
-  }, []);
+  const isTouch = useIsTouch();
 
   // Detect e: and a: prefix queries — suppress normal autocomplete, show hint row
   const prefixHint = useMemo(() => {

--- a/src/components/workspace/FindByNameBar.tsx
+++ b/src/components/workspace/FindByNameBar.tsx
@@ -632,7 +632,7 @@ export default function FindByNameBar({ showToast, registerFocusFn, registerSear
         <button
           onClick={onOpenMobileSidebar}
           aria-label="Open menu"
-          className="md:hidden w-9 h-9 shrink-0 flex items-center justify-center rounded-md text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
+          className="md:hidden w-11 h-11 shrink-0 flex items-center justify-center rounded-md text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
         >
           <Menu className="w-5 h-5" />
         </button>
@@ -682,17 +682,17 @@ export default function FindByNameBar({ showToast, registerFocusFn, registerSear
           spellCheck={false}
         />
         {!inputFocused && !query && !showPreview && (
-          <kbd className="text-[10px] text-content-disabled font-mono border border-line-subtle rounded px-1 py-0.5 shrink-0 select-none">
+          <kbd className="text-[11px] text-content-disabled font-mono border border-line-subtle rounded px-1.5 py-0.5 shrink-0 select-none">
             /
           </kbd>
         )}
         {(query || showPreview) && (
           <button
             onClick={() => clearAll()}
-            className="text-content-muted hover:text-content-primary transition-colors shrink-0 p-0.5"
+            className="w-8 h-8 flex items-center justify-center text-content-muted hover:text-content-primary transition-colors shrink-0"
             aria-label="Clear search"
           >
-            <X className="w-3.5 h-3.5" />
+            <X className="w-4 h-4" />
           </button>
         )}
       </div>
@@ -771,7 +771,7 @@ export default function FindByNameBar({ showToast, registerFocusFn, registerSear
             <button
               onClick={() => clearAll({ refocus: false })}
               aria-label="Close preview"
-              className="w-9 h-9 flex items-center justify-center text-content-muted hover:text-content-primary transition-colors"
+              className="w-11 h-11 -mr-2 flex items-center justify-center text-content-muted hover:text-content-primary transition-colors"
             >
               <X className="w-5 h-5" />
             </button>
@@ -840,9 +840,9 @@ export default function FindByNameBar({ showToast, registerFocusFn, registerSear
                       {warnings.map((w) => (
                         <span
                           key={w.type}
-                          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-yellow-500/10 border border-yellow-500/20 text-yellow-400"
+                          className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-[11px] font-medium bg-yellow-500/10 border border-yellow-500/20 text-yellow-400"
                         >
-                          <AlertTriangle className="w-2.5 h-2.5 shrink-0" />
+                          <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
                           {w.text}
                         </span>
                       ))}
@@ -851,7 +851,7 @@ export default function FindByNameBar({ showToast, registerFocusFn, registerSear
 
                   {/* Product Details */}
                   <div className="space-y-1 mb-3">
-                    <p className="text-[10px] font-semibold text-content-muted uppercase tracking-wider">Product Details</p>
+                    <p className="text-[11px] font-semibold text-content-muted uppercase tracking-wider">Product Details</p>
                     <div className="space-y-0.5 text-[11px]">
                       {displayArtist && (
                         <div className="flex gap-2">
@@ -915,7 +915,7 @@ export default function FindByNameBar({ showToast, registerFocusFn, registerSear
                     </>
                   ) : browseResults.length > 0 ? (
                     <>
-                      <p className="text-[10px] font-semibold text-content-muted uppercase tracking-wider mb-2">
+                      <p className="text-[11px] font-semibold text-content-muted uppercase tracking-wider mb-2">
                         {browseLabel} — {browseResults.length} card{browseResults.length !== 1 ? "s" : ""}
                       </p>
                       <div
@@ -966,7 +966,7 @@ export default function FindByNameBar({ showToast, registerFocusFn, registerSear
                               ) : frontImg ? (
                                 <img src={frontImg} alt={p.name} className="h-full w-auto" draggable={false} loading="lazy" />
                               ) : (
-                                <div className="h-full w-16 bg-surface-deep flex items-center justify-center text-[8px] text-content-muted">
+                                <div className="h-full w-16 bg-surface-deep flex items-center justify-center text-[11px] text-content-muted">
                                   {p.set.toUpperCase()}
                                 </div>
                               )}
@@ -981,9 +981,9 @@ export default function FindByNameBar({ showToast, registerFocusFn, registerSear
                                       if (alreadySelected) setFlipFace((f) => !f);
                                       else setFlipFace(true);
                                     }}
-                                    className="px-3 py-1 rounded-full text-[11px] font-medium border border-white/30 bg-white/10 hover:bg-white/25 hover:border-white/60 active:bg-white/35 text-white transition-colors flex items-center gap-1"
+                                    className="px-3 py-1.5 rounded-full text-[11px] font-medium border border-white/30 bg-white/10 hover:bg-white/25 hover:border-white/60 active:bg-white/35 text-white transition-colors flex items-center gap-1"
                                   >
-                                    <RotateCw className="w-3 h-3" /> Flip
+                                    <RotateCw className="w-4 h-4" /> Flip
                                   </button>
                                 )}
                                 <button
@@ -994,7 +994,7 @@ export default function FindByNameBar({ showToast, registerFocusFn, registerSear
                                     setFlipFace(false);
                                     handleAddCard(p);
                                   }}
-                                  className="px-3 py-1 rounded-md text-[11px] font-semibold bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white transition-colors"
+                                  className="px-3 py-1.5 rounded-md text-[11px] font-semibold bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white transition-colors"
                                 >
                                   + Add
                                 </button>
@@ -1012,7 +1012,7 @@ export default function FindByNameBar({ showToast, registerFocusFn, registerSear
                     </>
                   ) : (
                     <>
-                      <p className="text-[10px] font-semibold text-content-muted uppercase tracking-wider mb-2">
+                      <p className="text-[11px] font-semibold text-content-muted uppercase tracking-wider mb-2">
                         Art Variants — {printings.length} printing{printings.length !== 1 ? "s" : ""}
                       </p>
                       <div
@@ -1064,7 +1064,7 @@ export default function FindByNameBar({ showToast, registerFocusFn, registerSear
                               ) : frontImg ? (
                                 <img src={frontImg} alt={`${p.set_name} — ${p.set.toUpperCase()}`} className="h-full w-auto" width={488} height={680} draggable={false} loading="lazy" />
                               ) : (
-                                <div className="h-full w-16 bg-surface-deep flex items-center justify-center text-[8px] text-content-muted">
+                                <div className="h-full w-16 bg-surface-deep flex items-center justify-center text-[11px] text-content-muted">
                                   {p.set.toUpperCase()}
                                 </div>
                               )}
@@ -1079,9 +1079,9 @@ export default function FindByNameBar({ showToast, registerFocusFn, registerSear
                                       if (alreadySelected) setFlipFace((f) => !f);
                                       else setFlipFace(true);
                                     }}
-                                    className="px-3 py-1 rounded-full text-[11px] font-medium border border-white/30 bg-white/10 hover:bg-white/25 hover:border-white/60 active:bg-white/35 text-white transition-colors flex items-center gap-1"
+                                    className="px-3 py-1.5 rounded-full text-[11px] font-medium border border-white/30 bg-white/10 hover:bg-white/25 hover:border-white/60 active:bg-white/35 text-white transition-colors flex items-center gap-1"
                                   >
-                                    <RotateCw className="w-3 h-3" /> Flip
+                                    <RotateCw className="w-4 h-4" /> Flip
                                   </button>
                                 )}
                                 {!(entryMode === "deck" && p.id === deckEntryCardRef.current?.id) && (
@@ -1098,7 +1098,7 @@ export default function FindByNameBar({ showToast, registerFocusFn, registerSear
                                         handleAddCard(p);
                                       }
                                     }}
-                                    className="px-3 py-1 rounded-md text-[11px] font-semibold bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white transition-colors"
+                                    className="px-3 py-1.5 rounded-md text-[11px] font-semibold bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white transition-colors"
                                   >
                                     {entryMode === "deck" ? "Swap art" : "+ Add"}
                                   </button>

--- a/src/components/workspace/ImportModal.tsx
+++ b/src/components/workspace/ImportModal.tsx
@@ -34,7 +34,7 @@ export default function ImportModal({ pendingImport, activeDeckName, onProcess, 
         <div className="flex justify-end">
           <button 
             onClick={onCancel}
-            className="px-4 py-2 text-content-tertiary hover:text-content-primary text-sm font-bold transition-colors"
+            className="px-4 py-2.5 min-h-11 text-content-tertiary hover:text-content-primary text-sm font-bold transition-colors"
           >
             Cancel
           </button>

--- a/src/components/workspace/ListCardTable.tsx
+++ b/src/components/workspace/ListCardTable.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from "react";
-import { X } from "lucide-react";
+import { X, Minus, Plus } from "lucide-react";
 import { DeckCard, ScryfallCard } from "@/types";
 import { DeckFormat, getFormatRules, getCardWarnings, isEligibleCommander, isVehicleOrSpacecraftCommander, hasPartnerAbility } from "@/lib/formatRules";
 
@@ -256,10 +256,12 @@ export default function ListCardTable({
       rowBg = getRowTint(card);
     }
 
-    const qtyButtonBase = "w-5 h-5 rounded-full bg-surface-raised text-content-tertiary hover:bg-surface-overlay hover:text-white flex items-center justify-center transition-colors";
+    // Steppers stay visible at rest so they're reachable on touch (no hover);
+    // they just brighten on row hover for pointer users.
+    const qtyButtonBase = "w-7 h-7 rounded-full bg-surface-raised text-content-tertiary hover:bg-surface-overlay hover:text-white flex items-center justify-center transition-colors";
     const qtyButtonClass = isThisCommander
       ? qtyButtonBase
-      : `${qtyButtonBase} opacity-0 group-hover:opacity-100`;
+      : `${qtyButtonBase} opacity-70 group-hover:opacity-100`;
 
     return (
       <React.Fragment key={card.id}>
@@ -282,7 +284,7 @@ export default function ListCardTable({
           style={highlightedId !== card.id ? { backgroundColor: rowBg } : undefined}
         >
           {/* Owned toggle — circle ✓ button, 3 states matching grid badge */}
-          <td className="px-2 py-1 w-10">
+          <td className="px-2 py-2 w-10">
             <div className="flex items-center justify-center">
               {(() => {
                 const isPartial = card.isOwned && card.ownedQty > 0 && card.ownedQty < card.quantity;
@@ -317,8 +319,8 @@ export default function ListCardTable({
                     onMouseLeave={() => setToggleHoverId(null)}
                     title={card.isOwned ? "Unmark as owned" : "Mark as owned"}
                     style={{
-                      width: '20px',
-                      height: '20px',
+                      width: '28px',
+                      height: '28px',
                       borderRadius: '50%',
                       display: 'flex',
                       alignItems: 'center',
@@ -328,11 +330,11 @@ export default function ListCardTable({
                       color,
                       cursor: 'pointer',
                       transition: 'all 0.15s',
-                      fontSize: '10px',
+                      fontSize: '13px',
                       fontWeight: 700,
                       flexShrink: 0,
                     }}
-                    className={card.isOwned ? '' : 'opacity-0 group-hover:opacity-100'}
+                    className={card.isOwned ? '' : 'opacity-70 group-hover:opacity-100'}
                   >
                     ✓
                   </button>
@@ -342,15 +344,16 @@ export default function ListCardTable({
           </td>
 
           {/* Qty — [− owned X +] / [− qty Y +], steppers on row hover */}
-          <td className={`px-2 py-1 w-40 ${cellGrayscale}`} style={{ opacity: cellOpacity }}>
+          <td className={`px-2 py-2 w-52 ${cellGrayscale}`} style={{ opacity: cellOpacity }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
               {/* Owned sub-group */}
               <button
                 onClick={() => onUpdateOwnedQty(card.id, Math.max(0, card.ownedQty - 1))}
-                className="w-4 h-4 rounded-full bg-surface-raised text-content-tertiary hover:bg-surface-overlay hover:text-white flex items-center justify-center transition-colors opacity-0 group-hover:opacity-100"
+                aria-label="Decrease owned"
+                className="w-7 h-7 rounded-full bg-surface-raised text-content-tertiary hover:bg-surface-overlay hover:text-white flex items-center justify-center transition-colors opacity-70 group-hover:opacity-100"
                 style={{ flexShrink: 0 }}
               >
-                <svg width="6" height="6" viewBox="0 0 8 2" fill="currentColor"><rect x="0" y="0" width="8" height="2" /></svg>
+                <Minus className="w-3.5 h-3.5" />
               </button>
 
               {editingOwnedId === card.id ? (
@@ -367,13 +370,13 @@ export default function ListCardTable({
                     if (e.key === "Enter") { e.preventDefault(); commitOwnedEdit(card); }
                     if (e.key === "Escape") { isOwnedEscaping.current = true; setEditingOwnedId(null); }
                   }}
-                  className="w-5 text-center text-[10px] font-medium bg-surface-raised border border-blue-500 rounded text-green-400 focus:outline-none"
+                  className="w-6 text-center text-xs font-medium bg-surface-raised border border-blue-500 rounded text-green-400 focus:outline-none"
                   autoFocus
                 />
               ) : (
                 <span
                   onClick={() => startOwnedEdit(card)}
-                  className={`w-5 text-center text-[10px] tabular-nums cursor-pointer hover:underline ${
+                  className={`w-6 text-center text-xs tabular-nums cursor-pointer hover:underline ${
                     !card.isOwned || card.ownedQty === 0
                       ? 'text-content-disabled'
                       : isFullyOwned
@@ -387,22 +390,24 @@ export default function ListCardTable({
 
               <button
                 onClick={() => onUpdateOwnedQty(card.id, card.ownedQty + 1)}
-                className="w-4 h-4 rounded-full bg-surface-raised text-content-tertiary hover:bg-surface-overlay hover:text-white flex items-center justify-center transition-colors opacity-0 group-hover:opacity-100"
+                aria-label="Increase owned"
+                className="w-7 h-7 rounded-full bg-surface-raised text-content-tertiary hover:bg-surface-overlay hover:text-white flex items-center justify-center transition-colors opacity-70 group-hover:opacity-100"
                 style={{ flexShrink: 0 }}
               >
-                <svg width="6" height="6" viewBox="0 0 8 8" fill="currentColor"><rect x="3" y="0" width="2" height="8" /><rect x="0" y="3" width="8" height="2" /></svg>
+                <Plus className="w-3.5 h-3.5" />
               </button>
 
               {/* Slash separator */}
-              <span className="text-[10px] text-content-muted mx-0.5" style={{ userSelect: 'none' }}>/</span>
+              <span className="text-[11px] text-content-muted mx-0.5" style={{ userSelect: 'none' }}>/</span>
 
               {/* Qty sub-group */}
               <button
                 onClick={() => onUpdateQuantity(card.id, -1)}
+                aria-label="Decrease quantity"
                 className={qtyButtonClass}
                 style={{ flexShrink: 0 }}
               >
-                <svg width="6" height="6" viewBox="0 0 8 2" fill="currentColor"><rect x="0" y="0" width="8" height="2" /></svg>
+                <Minus className="w-3.5 h-3.5" />
               </button>
 
               {editingId === card.id ? (
@@ -419,7 +424,7 @@ export default function ListCardTable({
                     if (e.key === "Enter") { e.preventDefault(); commitEdit(card); }
                     if (e.key === "Escape") { isEscaping.current = true; setEditingId(null); }
                   }}
-                  className="w-6 text-center text-xs font-medium bg-surface-raised border border-blue-500 rounded text-content-heading focus:outline-none"
+                  className="w-7 text-center text-sm font-medium bg-surface-raised border border-blue-500 rounded text-content-heading focus:outline-none"
                   autoFocus
                 />
               ) : overCopyLimit ? (
@@ -430,7 +435,7 @@ export default function ListCardTable({
                   >
                     {card.quantity}
                   </span>
-                  <span className="absolute top-full mt-1.5 left-1/2 -translate-x-1/2 px-2 py-1 bg-surface-raised border border-line-default text-content-heading text-[9px] font-bold uppercase tracking-wider rounded opacity-0 group-hover/badge:opacity-100 transition-opacity pointer-events-none whitespace-normal max-w-xs z-50">
+                  <span className="absolute top-full mt-1.5 left-1/2 -translate-x-1/2 px-2 py-1 bg-surface-raised border border-line-default text-content-heading text-[11px] font-bold uppercase tracking-wider rounded opacity-0 group-hover/badge:opacity-100 transition-opacity pointer-events-none whitespace-normal max-w-xs z-50">
                     {format === "commander" ? "Exceeds singleton limit" : `Exceeds ${rules.copyLimit}-copy limit`}
                   </span>
                 </div>
@@ -445,17 +450,18 @@ export default function ListCardTable({
 
               <button
                 onClick={() => onUpdateQuantity(card.id, 1)}
+                aria-label="Increase quantity"
                 className={qtyButtonClass}
                 style={{ flexShrink: 0 }}
               >
-                <svg width="6" height="6" viewBox="0 0 8 8" fill="currentColor"><rect x="3" y="0" width="2" height="8" /><rect x="0" y="3" width="8" height="2" /></svg>
+                <Plus className="w-3.5 h-3.5" />
               </button>
             </div>
           </td>
 
           {/* Name — crown icon before, warning icon after */}
           <td
-            className={`px-2 py-1 min-w-0 ${cellGrayscale}`}
+            className={`px-2 py-2 min-w-0 ${cellGrayscale}`}
             style={{ opacity: cellOpacity }}
           >
             <div className="flex items-center gap-1 min-w-0">
@@ -468,7 +474,7 @@ export default function ListCardTable({
                     title={partnerInvalid ? partnerValidation?.warning : isCommander2 ? "Partner ✓ — click to remove" : "Commander ✓ — click to remove"}
                     className="shrink-0 cursor-pointer"
                   >
-                    <CrownFilled className={`w-3.5 h-3.5 ${partnerInvalid ? "text-red-400" : "text-yellow-400"}`} />
+                    <CrownFilled className={`w-4 h-4 ${partnerInvalid ? "text-red-400" : "text-yellow-400"}`} />
                   </button>
                 ) : (
                   // Non-commander hover crown with state machine
@@ -520,12 +526,12 @@ export default function ListCardTable({
                             title={!eligibleCommander && commanderCount === 0 ? "Must be Legendary to set as Commander" : undefined}
                             className={`opacity-0 group-hover:opacity-100 shrink-0 transition-opacity ${canAct ? "cursor-pointer" : "cursor-not-allowed"}`}
                           >
-                            <CrownOutline className={`w-3.5 h-3.5 ${canAct ? "text-content-faint hover:text-yellow-400" : "text-content-faint"}`} />
+                            <CrownOutline className={`w-4 h-4 ${canAct ? "text-content-faint hover:text-yellow-400" : "text-content-faint"}`} />
                           </button>
 
                           {hoveredCrownId === card.id && canAct && (
                             <div
-                              className="absolute left-full ml-1.5 top-1/2 -translate-y-1/2 px-2 py-1 bg-neutral-900 border border-neutral-700 rounded text-[10px] text-neutral-200 whitespace-nowrap z-30 flex items-center gap-1.5"
+                              className="absolute left-full ml-1.5 top-1/2 -translate-y-1/2 px-2 py-1 bg-neutral-900 border border-neutral-700 rounded text-xs text-neutral-200 whitespace-nowrap z-30 flex items-center gap-1.5"
                               onMouseEnter={() => {
                                 if (crownTooltipTimeout.current) {
                                   clearTimeout(crownTooltipTimeout.current);
@@ -590,16 +596,16 @@ export default function ListCardTable({
           </td>
 
           {/* Type */}
-          <td className={`px-2 py-1 text-[10px] text-content-muted truncate w-48 ${cellGrayscale}`} style={{ opacity: cellOpacity }}>
+          <td className={`px-2 py-2 text-[11px] text-content-muted truncate w-48 ${cellGrayscale}`} style={{ opacity: cellOpacity }}>
             {card.type_line || "—"}
           </td>
 
           {/* Mana */}
-          <td className={`px-2 py-1 w-24 ${cellGrayscale}`} style={{ opacity: cellOpacity }}>
+          <td className={`px-2 py-2 w-24 ${cellGrayscale}`} style={{ opacity: cellOpacity }}>
             {card.card_faces ? (
               <div className="flex items-center gap-1">
                 {renderManaSymbols(card.card_faces[0].mana_cost)}
-                <span className="text-[10px] text-content-faint font-bold">//</span>
+                <span className="text-[11px] text-content-faint font-bold">//</span>
                 {renderManaSymbols(card.card_faces[1].mana_cost)}
               </div>
             ) : (
@@ -609,18 +615,21 @@ export default function ListCardTable({
 
           {/* Price */}
           <td
-            className={`px-2 py-1 text-right text-[10px] tabular-nums w-20 text-content-tertiary ${cellGrayscale}`}
+            className={`px-2 py-2 text-right text-[11px] tabular-nums w-20 text-content-tertiary ${cellGrayscale}`}
             style={{ opacity: cellOpacity }}
           >
             {card.prices.usd ? `$${card.prices.usd}` : "N/A"}
           </td>
 
           {/* Remove */}
-          <td className="pr-3 py-1 text-center w-8">
-            <X
+          <td className="pr-2 py-2 text-center w-10">
+            <button
               onClick={() => onRemove(card.id)}
-              className="w-3 h-3 inline cursor-pointer text-content-disabled hover:text-red-500"
-            />
+              aria-label="Remove card"
+              className="w-7 h-7 inline-flex items-center justify-center rounded-full text-content-disabled hover:text-red-500 hover:bg-surface-raised transition-colors"
+            >
+              <X className="w-4 h-4" />
+            </button>
           </td>
         </tr>
       </React.Fragment>
@@ -632,17 +641,17 @@ export default function ListCardTable({
       className="bg-surface-base border border-line-subtle rounded-lg shadow-sm"
       onMouseMove={onMouseMove}
     >
-      <table className="w-full table-fixed text-left text-xs">
+      <table className="w-full table-fixed text-left text-sm">
         {showHeader && (
-          <thead className="bg-surface-base text-[10px] text-content-muted border-b border-line-subtle uppercase tracking-wider">
+          <thead className="bg-surface-base text-[11px] text-content-muted border-b border-line-subtle uppercase tracking-wider">
             <tr>
               <th className="px-2 py-1.5 w-10"></th>
-              <th className="px-2 py-1.5 w-40">Qty</th>
+              <th className="px-2 py-1.5 w-52">Qty</th>
               <th className="px-2 py-1.5 min-w-0">Name</th>
               <th className="px-2 py-1.5 w-48">Type</th>
               <th className="px-2 py-1.5 w-24">Mana</th>
               <th className="px-2 py-1.5 text-right w-20">Price</th>
-              <th className="pr-3 py-1.5 w-8 text-center"></th>
+              <th className="pr-2 py-1.5 w-10 text-center"></th>
             </tr>
           </thead>
         )}

--- a/src/components/workspace/SearchBar.tsx
+++ b/src/components/workspace/SearchBar.tsx
@@ -30,7 +30,7 @@ function ManaPip({ symbol }: { symbol: string }) {
   return (
     <img
       src={`https://svgs.scryfall.io/card-symbols/${symbol}.svg`}
-      className="w-3 h-3 inline-block"
+      className="w-4 h-4 inline-block"
       alt={symbol}
     />
   );
@@ -68,14 +68,14 @@ export default function SearchBar({
   return (
     <div ref={containerRef} className="flex-1 relative min-w-0">
       {/* Search bar row */}
-      <div className="flex items-center flex-wrap min-w-0 bg-surface-deep border border-line-subtle rounded-lg px-2 gap-1 min-h-[40px] transition-colors focus-within:border-input-edge-focus">
-        <Search size={14} className="text-content-muted shrink-0" />
+      <div className="flex items-center flex-wrap min-w-0 bg-surface-deep border border-line-subtle rounded-lg px-2 gap-1 min-h-[44px] transition-colors focus-within:border-input-edge-focus">
+        <Search size={16} className="text-content-muted shrink-0" />
 
         {/* Filter badge */}
         {filterBadge && (
           <span
             onClick={onToggleFilter}
-            className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] shrink-0 cursor-pointer transition-colors select-none ${
+            className={`inline-flex items-center gap-1 px-2 py-1 rounded text-[11px] shrink-0 cursor-pointer transition-colors select-none ${
               filterBadge.active
                 ? filterBadge.label.toLowerCase() === "commander"
                   ? "bg-yellow-900/30 border border-yellow-500/25 text-yellow-400"
@@ -85,7 +85,7 @@ export default function SearchBar({
                 : "bg-surface-raised border border-line-default text-content-muted"
             }`}
           >
-            <Lock size={9} />
+            <Lock size={13} />
             {filterBadge.label}
             {filterBadge.manaColors?.map((color) => (
               <ManaPip key={color} symbol={color} />
@@ -95,7 +95,8 @@ export default function SearchBar({
                 e.stopPropagation();
                 onToggleFilter();
               }}
-              className="opacity-60 hover:opacity-100 leading-none"
+              aria-label="Clear filter"
+              className="opacity-60 hover:opacity-100 leading-none px-1 text-base"
             >
               ×
             </button>
@@ -107,14 +108,14 @@ export default function SearchBar({
           <span
             key={i}
             onClick={() => onRemoveToken(i)}
-            className="inline-flex items-center gap-1 px-1.5 py-0.5 bg-surface-raised border border-line-default rounded text-[10px] text-content-secondary shrink-0 cursor-pointer transition-colors hover:border-red-500/60 hover:text-red-400 group select-none"
+            className="inline-flex items-center gap-1 px-2 py-1 bg-surface-raised border border-line-default rounded text-[11px] text-content-secondary shrink-0 cursor-pointer transition-colors hover:border-red-500/60 hover:text-red-400 group select-none"
             title="Click to remove"
           >
-            <span className="text-content-muted text-[9px] uppercase tracking-wide">
+            <span className="text-content-muted text-[11px] uppercase tracking-wide">
               {token.label}:
             </span>
             {token.value}
-            <span className="text-[9px] opacity-0 group-hover:opacity-100 transition-opacity leading-none">
+            <span className="text-[11px] opacity-60 group-hover:opacity-100 transition-opacity leading-none">
               ×
             </span>
           </span>
@@ -130,16 +131,17 @@ export default function SearchBar({
             if (e.key === "Escape" || e.key === "Enter") onDismissAutocomplete();
           }}
           placeholder={tokens.length > 0 ? "Add more filters..." : "Search for cards, types, keywords..."}
-          className="flex-1 min-w-[80px] bg-transparent border-none text-input-value text-xs outline-none placeholder:text-input-placeholder py-0.5"
+          className="flex-1 min-w-[80px] bg-transparent border-none text-input-value text-sm outline-none placeholder:text-input-placeholder py-1"
         />
 
         {/* Clear button */}
         {(query || tokens.length > 0) && (
           <button
             onClick={onClear}
-            className="w-4 h-4 flex items-center justify-center rounded-full text-content-muted hover:text-content-secondary hover:bg-surface-overlay transition-colors shrink-0"
+            aria-label="Clear search"
+            className="w-7 h-7 flex items-center justify-center rounded-full text-content-muted hover:text-content-secondary hover:bg-surface-overlay transition-colors shrink-0"
           >
-            <X size={10} />
+            <X size={16} />
           </button>
         )}
       </div>
@@ -150,7 +152,7 @@ export default function SearchBar({
           {/* Card name matches */}
           {autocompleteSuggestions.length > 0 && (
             <div className="py-1">
-              <div className="px-2.5 py-1 text-[9px] text-content-muted uppercase tracking-wider">
+              <div className="px-2.5 py-1 text-[11px] text-content-muted uppercase tracking-wider">
                 Cards
               </div>
               {autocompleteSuggestions.slice(0, 5).map((name) => (
@@ -160,7 +162,7 @@ export default function SearchBar({
                     e.preventDefault(); // prevent input blur before click
                     onSelectAutocomplete(name);
                   }}
-                  className="w-full flex items-center gap-2 px-2.5 py-1.5 text-xs text-content-secondary hover:bg-surface-raised hover:text-content-primary transition-colors text-left"
+                  className="w-full flex items-center gap-2 px-2.5 py-2.5 text-sm text-content-secondary hover:bg-surface-raised hover:text-content-primary transition-colors text-left"
                 >
                   {deckCardNames.has(name) && (
                     <span className="w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" />
@@ -174,7 +176,7 @@ export default function SearchBar({
           {/* Parsed token preview */}
           {tokens.length > 0 && (
             <div className="px-2.5 py-2 border-t border-line-subtle flex flex-wrap gap-1 items-center">
-              <span className="text-[9px] text-content-muted mr-1">Parsed:</span>
+              <span className="text-[11px] text-content-muted mr-1">Parsed:</span>
               {tokens.map((token, i) => (
                 <span
                   key={i}
@@ -182,9 +184,9 @@ export default function SearchBar({
                     e.preventDefault();
                     onRemoveToken(i);
                   }}
-                  className="inline-flex items-center gap-1 px-1.5 py-0.5 bg-surface-raised border border-line-default rounded text-[10px] text-content-secondary cursor-pointer hover:border-red-500/60 hover:text-red-400 select-none"
+                  className="inline-flex items-center gap-1 px-2 py-1 bg-surface-raised border border-line-default rounded text-[11px] text-content-secondary cursor-pointer hover:border-red-500/60 hover:text-red-400 select-none"
                 >
-                  <span className="text-content-muted text-[9px] uppercase tracking-wide">
+                  <span className="text-content-muted text-[11px] uppercase tracking-wide">
                     {token.label}:
                   </span>
                   {token.value}

--- a/src/components/workspace/SearchListTable.tsx
+++ b/src/components/workspace/SearchListTable.tsx
@@ -80,7 +80,7 @@ export default function SearchListTable({ cards, deckCardNames, onAdd, onSelect,
     <div onMouseMove={handleMouseMove}>
       <div className="bg-surface-base border border-line-subtle rounded-lg shadow-sm" style={{ margin: "10px" }}>
         <table className="w-full table-fixed text-left text-xs">
-          <thead className="bg-surface-base text-[10px] text-content-muted border-b border-line-subtle uppercase tracking-wider">
+          <thead className="bg-surface-base text-[11px] text-content-muted border-b border-line-subtle uppercase tracking-wider">
             <tr>
               <th className="px-2 py-1.5 w-10"></th>
               <th className="px-2 py-1.5 w-8">Own</th>
@@ -106,12 +106,13 @@ export default function SearchListTable({ cards, deckCardNames, onAdd, onSelect,
                   style={{ backgroundColor: rowBg }}
                 >
                   {/* + Add button */}
-                  <td className="px-2 py-1 w-10">
+                  <td className="px-2 py-2 w-10">
                     <div className="flex items-center justify-center">
                       <button
                         onClick={(e) => { e.stopPropagation(); onAdd(card); }}
                         title="Add to deck"
-                        className="w-[22px] h-[22px] rounded-full border border-white/10 flex items-center justify-center text-content-tertiary text-xs opacity-0 group-hover:opacity-100 transition-opacity hover:bg-blue-500/15 hover:border-blue-500/30 hover:text-blue-400"
+                        aria-label="Add to deck"
+                        className="w-7 h-7 rounded-full border border-white/10 flex items-center justify-center text-content-tertiary text-base opacity-60 group-hover:opacity-100 transition-opacity hover:bg-blue-500/15 hover:border-blue-500/30 hover:text-blue-400"
                       >
                         +
                       </button>
@@ -119,7 +120,7 @@ export default function SearchListTable({ cards, deckCardNames, onAdd, onSelect,
                   </td>
 
                   {/* In-deck indicator */}
-                  <td className="px-1 py-1 w-5">
+                  <td className="px-1 py-2 w-5">
                     <div className="flex items-center justify-center">
                       {inDeck && (
                         <span
@@ -131,23 +132,23 @@ export default function SearchListTable({ cards, deckCardNames, onAdd, onSelect,
                   </td>
 
                   {/* Name */}
-                  <td className="px-2 py-1 min-w-0">
+                  <td className="px-2 py-2 min-w-0">
                     <span className={`truncate font-medium block ${inDeck ? "text-content-tertiary" : "text-content-primary"}`}>
                       {card.name}
                     </span>
                   </td>
 
                   {/* Type */}
-                  <td className={`px-2 py-1 text-[10px] truncate w-48 ${inDeck ? "text-content-faint" : "text-content-tertiary"}`}>
+                  <td className={`px-2 py-2 text-[11px] truncate w-48 ${inDeck ? "text-content-faint" : "text-content-tertiary"}`}>
                     {card.type_line || "—"}
                   </td>
 
                   {/* Mana */}
-                  <td className={`px-2 py-1 w-24 ${inDeck ? "opacity-40" : ""}`}>
+                  <td className={`px-2 py-2 w-24 ${inDeck ? "opacity-40" : ""}`}>
                     {card.card_faces ? (
                       <div className="flex items-center gap-1">
                         {renderManaSymbols(card.card_faces[0].mana_cost)}
-                        <span className="text-[10px] text-content-faint font-bold">//</span>
+                        <span className="text-[11px] text-content-faint font-bold">//</span>
                         {renderManaSymbols(card.card_faces[1].mana_cost)}
                       </div>
                     ) : (
@@ -156,7 +157,7 @@ export default function SearchListTable({ cards, deckCardNames, onAdd, onSelect,
                   </td>
 
                   {/* Price */}
-                  <td className={`px-2 py-1 text-right text-[10px] tabular-nums w-20 ${inDeck ? "text-content-faint" : "text-content-tertiary"}`}>
+                  <td className={`px-2 py-2 text-right text-[11px] tabular-nums w-20 ${inDeck ? "text-content-faint" : "text-content-tertiary"}`}>
                     {card.prices.usd ? `$${card.prices.usd}` : "N/A"}
                   </td>
                 </tr>

--- a/src/components/workspace/SearchTakeover.tsx
+++ b/src/components/workspace/SearchTakeover.tsx
@@ -55,7 +55,7 @@ export default function SearchTakeover({ onSearch, onTagSelect }: SearchTakeover
               key={tag}
               onClick={() => onTagSelect(tag)}
               className="
-                text-xs py-1.5 px-3.5 rounded-full
+                text-sm py-2.5 px-4 rounded-full
                 bg-surface-raised border border-line-default
                 text-content-secondary
                 hover:bg-[color:var(--input-edge-focus)]/8

--- a/src/components/workspace/SettingsView.tsx
+++ b/src/components/workspace/SettingsView.tsx
@@ -177,7 +177,7 @@ function PreferencesTab({ showToast, onClose }: PreferencesTabProps) {
                 "linear-gradient(135deg, #1c1917, #292524 50%, #3f3a36)",
             }}
           >
-            <span className="absolute bottom-0 inset-x-0 px-2 py-1 bg-black/50 text-[9px] font-bold uppercase tracking-wide text-content-secondary text-left">
+            <span className="absolute bottom-0 inset-x-0 px-2 py-1 bg-black/50 text-[11px] font-bold uppercase tracking-wide text-content-secondary text-left">
               Warm Stone
             </span>
           </button>
@@ -195,7 +195,7 @@ function PreferencesTab({ showToast, onClose }: PreferencesTabProps) {
                 "linear-gradient(135deg, #282c34, #2c313a 50%, #3a3f47)",
             }}
           >
-            <span className="absolute bottom-0 inset-x-0 px-2 py-1 bg-black/50 text-[9px] font-bold uppercase tracking-wide text-content-secondary text-left">
+            <span className="absolute bottom-0 inset-x-0 px-2 py-1 bg-black/50 text-[11px] font-bold uppercase tracking-wide text-content-secondary text-left">
               Zed Dark
             </span>
           </button>
@@ -213,23 +213,23 @@ function PreferencesTab({ showToast, onClose }: PreferencesTabProps) {
             onClick={handleBackup}
             disabled={decks.length === 0}
             title={decks.length === 0 ? "No decks to back up" : undefined}
-            className={`flex items-center gap-1.5 px-4 py-2 bg-surface-raised hover:bg-surface-overlay border border-line-default rounded-lg text-xs text-content-secondary hover:text-content-primary transition-colors ${decks.length === 0 ? "opacity-50 cursor-not-allowed" : ""}`}
+            className={`flex items-center gap-1.5 px-4 py-2.5 min-h-11 bg-surface-raised hover:bg-surface-overlay border border-line-default rounded-lg text-xs text-content-secondary hover:text-content-primary transition-colors ${decks.length === 0 ? "opacity-50 cursor-not-allowed" : ""}`}
           >
-            <Download className="w-3.5 h-3.5" />
+            <Download className="w-4 h-4" />
             Backup All Decks
           </button>
           <button
             onClick={handleRestoreClick}
-            className="flex items-center gap-1.5 px-4 py-2 bg-surface-raised hover:bg-surface-overlay border border-line-default rounded-lg text-xs text-content-secondary hover:text-content-primary transition-colors"
+            className="flex items-center gap-1.5 px-4 py-2.5 min-h-11 bg-surface-raised hover:bg-surface-overlay border border-line-default rounded-lg text-xs text-content-secondary hover:text-content-primary transition-colors"
           >
-            <Upload className="w-3.5 h-3.5" />
+            <Upload className="w-4 h-4" />
             Restore from Backup
           </button>
         </div>
         {backupError && (
           <p className="text-xs text-red-400 mt-2">{backupError}</p>
         )}
-        <p className="text-[10px] text-content-faint mt-2">
+        <p className="text-[11px] text-content-faint mt-2">
           {lastBackup ? `Last backup: ${formatBackupDate(lastBackup)}` : "No backups yet"}
         </p>
         <input
@@ -246,7 +246,7 @@ function PreferencesTab({ showToast, onClose }: PreferencesTabProps) {
         <p className="text-xs text-content-disabled">
           More preferences coming soon
         </p>
-        <p className="text-[10px] font-bold uppercase tracking-wide text-content-faint mt-1.5">
+        <p className="text-[11px] font-bold uppercase tracking-wide text-content-faint mt-1.5">
           Animations · Token Gallery · Display density
         </p>
       </div>
@@ -287,13 +287,13 @@ function PreferencesTab({ showToast, onClose }: PreferencesTabProps) {
             <div className="flex justify-end gap-3 mt-5">
               <button
                 onClick={() => setRestoreData(null)}
-                className="px-4 py-2 rounded-lg text-sm text-content-secondary hover:text-content-primary hover:bg-surface-raised transition-colors"
+                className="px-4 py-2.5 min-h-11 rounded-lg text-sm text-content-secondary hover:text-content-primary hover:bg-surface-raised transition-colors"
               >
                 Cancel
               </button>
               <button
                 onClick={handleConfirmRestore}
-                className="px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-500 transition-colors"
+                className="px-4 py-2.5 min-h-11 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-500 transition-colors"
               >
                 Restore
               </button>
@@ -317,11 +317,11 @@ function WhatsNewTab() {
           {index > 0 && <div className="border-b border-line-subtle my-5" />}
           <div className="mb-2">
             {index === 0 ? (
-              <span className="inline-flex items-center px-2 py-0.5 bg-blue-500/10 border border-blue-500/20 text-blue-400 text-[9px] font-bold uppercase tracking-wider rounded-full">
+              <span className="inline-flex items-center px-2 py-1 bg-blue-500/10 border border-blue-500/20 text-blue-400 text-[11px] font-bold uppercase tracking-wider rounded-full">
                 v{version}
               </span>
             ) : (
-              <p className="text-[10px] font-bold text-content-disabled">
+              <p className="text-[11px] font-bold text-content-disabled">
                 v{version}
               </p>
             )}
@@ -372,7 +372,7 @@ function AboutTab() {
       </p>
 
       {/* Team */}
-      <p className="text-[10px] font-bold uppercase tracking-widest text-content-muted mb-2">
+      <p className="text-[11px] font-bold uppercase tracking-widest text-content-muted mb-2">
         Team
       </p>
       <MonogramRow
@@ -389,7 +389,7 @@ function AboutTab() {
       <div className="border-b border-line-subtle my-5" />
 
       {/* Powered By */}
-      <p className="text-[10px] font-bold uppercase tracking-widest text-content-muted mb-2">
+      <p className="text-[11px] font-bold uppercase tracking-widest text-content-muted mb-2">
         Powered By
       </p>
       <MonogramRow
@@ -411,19 +411,19 @@ function AboutTab() {
       <div className="border-b border-line-subtle my-5" />
 
       {/* Legal */}
-      <p className="text-[10px] font-bold uppercase tracking-widest text-content-muted mb-2">
+      <p className="text-[11px] font-bold uppercase tracking-widest text-content-muted mb-2">
         Legal
       </p>
-      <p className="text-[10px] text-content-disabled leading-relaxed mb-3">
+      <p className="text-[11px] text-content-disabled leading-relaxed mb-3">
         Project Brew is unofficial Fan Content permitted under the Fan Content
         Policy. Not approved/endorsed by Wizards. Portions of the materials used
         are property of Wizards of the Coast. ©Wizards of the Coast LLC.
       </p>
-      <p className="text-[10px] text-content-disabled leading-relaxed mb-3">
+      <p className="text-[11px] text-content-disabled leading-relaxed mb-3">
         Card data and images provided by Scryfall. Project Brew is not produced
         by or endorsed by Scryfall.
       </p>
-      <p className="text-[10px] text-content-disabled leading-relaxed mb-3">
+      <p className="text-[11px] text-content-disabled leading-relaxed mb-3">
         Magic: The Gathering is a trademark of Wizards of the Coast LLC.
       </p>
     </div>
@@ -486,7 +486,7 @@ function SupportTab() {
         <p className="text-xs text-content-disabled">
           Bug reports, feature requests, and feedback
         </p>
-        <p className="text-[10px] font-bold uppercase tracking-wide text-content-faint mt-1.5">
+        <p className="text-[11px] font-bold uppercase tracking-wide text-content-faint mt-1.5">
           Coming soon
         </p>
       </div>
@@ -519,14 +519,15 @@ export default function SettingsView({
           <div className="flex items-center gap-2">
             <button
               onClick={onClose}
-              className="w-8 h-8 rounded-lg flex items-center justify-center text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors shrink-0"
+              aria-label="Back"
+              className="w-11 h-11 -ml-2 rounded-lg flex items-center justify-center text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors shrink-0"
             >
               <ChevronLeft className="w-5 h-5" />
             </button>
             <h1 className="text-xl font-extrabold text-content-primary tracking-tight">
               Project Brew
             </h1>
-            <span className="ml-auto inline-flex items-center px-2 py-0.5 bg-blue-500/10 border border-blue-500/20 text-blue-400 text-[9px] font-bold uppercase tracking-wider rounded-full shrink-0">
+            <span className="ml-auto inline-flex items-center px-2 py-1 bg-blue-500/10 border border-blue-500/20 text-blue-400 text-[11px] font-bold uppercase tracking-wider rounded-full shrink-0">
               v{APP_VERSION}
             </span>
           </div>
@@ -543,7 +544,7 @@ export default function SettingsView({
             <button
               key={tab.id}
               onClick={() => onTabChange(tab.id)}
-              className={`px-4 py-2.5 text-xs font-semibold border-b-2 transition-colors whitespace-nowrap ${
+              className={`px-4 py-3 min-h-11 text-sm font-semibold border-b-2 transition-colors whitespace-nowrap ${
                 activeTab === tab.id
                   ? "text-content-primary border-line-focus"
                   : "text-content-muted hover:text-content-secondary border-transparent"

--- a/src/components/workspace/TileSizeSlider.tsx
+++ b/src/components/workspace/TileSizeSlider.tsx
@@ -113,7 +113,7 @@ export default function TileSizeSlider({ activeStop, onChangeStop }: TileSizeSli
             : "text-content-muted hover:text-content-secondary border border-transparent"
         }`}
       >
-        <ZoomIn className="w-3.5 h-3.5" />
+        <ZoomIn className="w-4 h-4" />
       </button>
 
       {/* Always in DOM — visibility controlled by opacity + pointer-events for smooth transition */}

--- a/src/components/workspace/VisualCard.tsx
+++ b/src/components/workspace/VisualCard.tsx
@@ -82,7 +82,7 @@ export default function VisualCard({
             <span className="text-xs font-semibold text-content-primary text-center leading-tight line-clamp-2">
               {card.name}
             </span>
-            <span className="text-[10px] text-content-tertiary truncate w-full text-center">
+            <span className="text-xs text-content-tertiary truncate w-full text-center">
               {card.type_line}
             </span>
             <button
@@ -253,8 +253,8 @@ export default function VisualCard({
   const stepperBtn = (visible: boolean, btnId: string): React.CSSProperties => {
     const hovered = hoveredBtn === btnId && visible;
     return {
-      width: '24px',
-      height: '24px',
+      width: '28px',
+      height: '28px',
       borderRadius: '50%',
       display: 'flex',
       alignItems: 'center',
@@ -299,9 +299,10 @@ export default function VisualCard({
             e.stopPropagation();
             onRemove(card.id);
           }}
-          className="absolute top-1.5 right-1.5 w-6 h-6 flex items-center justify-center rounded-full bg-surface-base text-content-tertiary hover:text-red-400 hover:bg-red-900 opacity-0 group-hover:opacity-100 transition-all z-30"
+          aria-label="Remove card"
+          className="absolute top-1.5 right-1.5 w-7 h-7 flex items-center justify-center rounded-full bg-surface-base text-content-tertiary hover:text-red-400 hover:bg-red-900 opacity-0 group-hover:opacity-100 transition-all z-30"
         >
-          <X className="w-3 h-3" />
+          <X className="w-4 h-4" />
         </button>
 
         {/* Slide-up bottom overlay */}
@@ -315,7 +316,7 @@ export default function VisualCard({
             {card.name}
           </span>
           {/* Type line */}
-          <span className="text-[10px] text-content-tertiary truncate w-full text-center -mt-1">
+          <span className="text-xs text-content-tertiary truncate w-full text-center -mt-1">
             {card.type_line}
           </span>
 
@@ -339,7 +340,7 @@ export default function VisualCard({
                 <path d="M12 9v4" stroke="#171717" strokeWidth="2.2" strokeLinecap="round" fill="none" />
                 <circle cx="12" cy="17" r="1" fill="#171717" />
               </svg>
-              <span style={{ fontSize: '10px', fontWeight: 600, color: '#f87171', whiteSpace: 'nowrap' }}>
+              <span style={{ fontSize: '11px', fontWeight: 600, color: '#f87171', whiteSpace: 'nowrap' }}>
                 {warnings[0]}
               </span>
             </div>
@@ -362,7 +363,7 @@ export default function VisualCard({
                   onUpdateOwnedQty(card.id, Math.max(0, card.ownedQty - 1));
                 }}
               >
-                <Minus style={{ width: '10px', height: '10px' }} />
+                <Minus style={{ width: '14px', height: '14px' }} />
               </button>
 
               {isOwnedEditing ? (
@@ -401,7 +402,7 @@ export default function VisualCard({
                   onUpdateOwnedQty(card.id, card.ownedQty + 1);
                 }}
               >
-                <Plus style={{ width: '10px', height: '10px' }} />
+                <Plus style={{ width: '14px', height: '14px' }} />
               </button>
             </div>
 
@@ -423,7 +424,7 @@ export default function VisualCard({
                   onUpdateQuantity(card.id, -1);
                 }}
               >
-                <Minus style={{ width: '10px', height: '10px' }} />
+                <Minus style={{ width: '14px', height: '14px' }} />
               </button>
 
               {isEditing ? (
@@ -466,7 +467,7 @@ export default function VisualCard({
                   onUpdateQuantity(card.id, 1);
                 }}
               >
-                <Plus style={{ width: '10px', height: '10px' }} />
+                <Plus style={{ width: '14px', height: '14px' }} />
               </button>
             </div>
           </div>
@@ -544,7 +545,7 @@ export default function VisualCard({
 
                   {showCrownTooltip && canAct && (
                     <div
-                      className="absolute left-1/2 -translate-x-1/2 top-full mt-1 px-2 py-1 bg-neutral-900 border border-neutral-700 rounded text-[10px] text-neutral-200 whitespace-nowrap z-30 flex items-center gap-1.5"
+                      className="absolute left-1/2 -translate-x-1/2 top-full mt-1 px-2 py-1 bg-neutral-900 border border-neutral-700 rounded text-xs text-neutral-200 whitespace-nowrap z-30 flex items-center gap-1.5"
                       onMouseEnter={() => {
                         if (crownTooltipTimeout.current) { clearTimeout(crownTooltipTimeout.current); crownTooltipTimeout.current = null; }
                       }}

--- a/src/components/workspace/VisualCard.tsx
+++ b/src/components/workspace/VisualCard.tsx
@@ -1,6 +1,7 @@
 import { Minus, Plus, X } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { DeckCard, ScryfallCard } from '@/types';
+import { useIsTouch } from '@/hooks/useIsTouch';
 import { DeckFormat, getCardWarnings, isEligibleCommander, isVehicleOrSpacecraftCommander, hasPartnerAbility } from '@/lib/formatRules';
 import { TileSizeKey } from '@/config/gridConfig';
 
@@ -62,6 +63,26 @@ export default function VisualCard({
   tileSize = "m",
 }: VisualCardProps) {
   const badgeSize = PRICE_BADGE_SIZES[tileSize];
+
+  // Touch: the desktop edit overlay is hover-driven and unreachable on touch.
+  // Instead, tapping the qty badge reveals a slim bottom bar with the same
+  // controls (full parity). Declared before the search-mode early return so the
+  // hook order stays stable. Pointer/hover behaviour is left untouched.
+  const isTouch = useIsTouch();
+  const [barOpen, setBarOpen] = useState(false);
+  const cardRootRef = useRef<HTMLDivElement>(null);
+
+  // Close the touch bar on a tap/scroll anywhere outside this card.
+  useEffect(() => {
+    if (!barOpen) return;
+    const onDown = (e: Event) => {
+      if (cardRootRef.current && !cardRootRef.current.contains(e.target as Node)) {
+        setBarOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", onDown);
+    return () => document.removeEventListener("pointerdown", onDown);
+  }, [barOpen]);
 
   // Search mode — simplified tile with "+ Add to Deck" overlay
   if (mode === "search") {
@@ -234,10 +255,13 @@ export default function VisualCard({
     badgeCheckColor = isBadgeHovered ? '#f87171' : '#fff';
   }
 
-  const activeBadgeBg = isCardHovered ? badgeCheckBg : badgeRestBg;
-  const activeBadgeBorder = isCardHovered ? badgeCheckBorder : badgeRestBorder;
-  const activeBadgeColor = isCardHovered ? badgeCheckColor : badgeRestColor;
-  const badgeBottom = isCardHovered ? badgeTargetBottom : '-12px';
+  // On touch, ignore emulated hover so the badge stays a stable qty chip (the
+  // tap-to-reveal trigger) instead of flipping to the desktop ✓ toggle state.
+  const badgeHoverActive = !isTouch && isCardHovered;
+  const activeBadgeBg = badgeHoverActive ? badgeCheckBg : badgeRestBg;
+  const activeBadgeBorder = badgeHoverActive ? badgeCheckBorder : badgeRestBorder;
+  const activeBadgeColor = badgeHoverActive ? badgeCheckColor : badgeRestColor;
+  const badgeBottom = badgeHoverActive ? badgeTargetBottom : '-12px';
 
   // Owned number color in overlay — dim when not tracking (isOwned=false)
   const ownedNumColor = !card.isOwned || card.ownedQty === 0
@@ -273,8 +297,14 @@ export default function VisualCard({
 
   return (
     <div
+      ref={cardRootRef}
       className="relative group rounded-xl cursor-pointer aspect-[2.5/3.5]"
-      onClick={() => onSelect(card)}
+      onClick={() => {
+        // On touch, if the edit bar is open a tap on the art dismisses it
+        // (rather than opening the card preview).
+        if (isTouch && barOpen) { setBarOpen(false); return; }
+        onSelect(card);
+      }}
       onMouseEnter={() => {
         setIsCardHovered(true);
         if (overlayRef.current) {
@@ -533,7 +563,7 @@ export default function VisualCard({
                   <button
                     onClick={(e) => { e.stopPropagation(); if (canAct && crownAction) crownAction(); }}
                     title={!eligible && commanderCount === 0 ? "Must be Legendary" : undefined}
-                    className={`w-7 h-7 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 border border-neutral-600 bg-neutral-900/70 shadow-md transition-all duration-150 ${canAct ? "hover:bg-yellow-500/20 hover:border-yellow-400 hover:scale-110 cursor-pointer group/crown" : "cursor-not-allowed"}`}
+                    className={`w-7 h-7 rounded-full flex items-center justify-center ${isTouch ? "opacity-90" : "opacity-0 group-hover:opacity-100"} border border-neutral-600 bg-neutral-900/70 shadow-md transition-all duration-150 ${canAct ? "hover:bg-yellow-500/20 hover:border-yellow-400 hover:scale-110 cursor-pointer group/crown" : "cursor-not-allowed"}`}
                   >
                     <svg width="16" height="16" viewBox="0 0 24 24">
                       <path
@@ -578,33 +608,41 @@ export default function VisualCard({
       {/* Qty/owned badge — bottom-center, animates to overlay-top on card hover and becomes ✓ toggle */}
       <div
         onClick={(e) => {
+          // Touch: the badge is the reveal trigger for the edit bar.
+          if (isTouch) {
+            e.stopPropagation();
+            setBarOpen((o) => !o);
+            return;
+          }
           if (!isCardHovered) return;
           e.stopPropagation();
           onToggleIsOwned(card.id);
         }}
         onMouseEnter={() => { if (isCardHovered) setIsBadgeHovered(true); }}
         onMouseLeave={() => setIsBadgeHovered(false)}
-        title={isCardHovered ? (card.isOwned ? "Unmark as owned" : "Mark as owned") : undefined}
+        title={isTouch ? "Edit quantities" : isCardHovered ? (card.isOwned ? "Unmark as owned" : "Mark as owned") : undefined}
         style={{
           position: 'absolute',
           left: '50%',
           transform: 'translateX(-50%)',
           bottom: badgeBottom,
-          width: '24px',
-          height: '24px',
+          width: isTouch ? '30px' : '24px',
+          height: isTouch ? '30px' : '24px',
           borderRadius: '50%',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          transition: 'bottom 0.25s cubic-bezier(0.4,0,0.2,1), background 0.15s, border-color 0.15s, color 0.15s',
+          transition: 'bottom 0.25s cubic-bezier(0.4,0,0.2,1), opacity 0.15s, background 0.15s, border-color 0.15s, color 0.15s',
           zIndex: 25,
           border: `1px solid ${activeBadgeBorder}`,
           background: activeBadgeBg,
           color: activeBadgeColor,
-          cursor: isCardHovered ? 'pointer' : 'default',
+          cursor: (isCardHovered || isTouch) ? 'pointer' : 'default',
           userSelect: 'none',
           boxShadow: '0 2px 6px rgba(0,0,0,0.5)',
           overflow: 'hidden',
+          opacity: isTouch && barOpen ? 0 : 1,
+          pointerEvents: isTouch && barOpen ? 'none' : 'auto',
         }}
       >
         {/* Qty number — visible at rest */}
@@ -613,7 +651,7 @@ export default function VisualCard({
           fontSize: '11px',
           fontWeight: 700,
           fontVariantNumeric: 'tabular-nums',
-          opacity: isCardHovered ? 0 : 1,
+          opacity: badgeHoverActive ? 0 : 1,
           transition: 'opacity 0.15s',
           pointerEvents: 'none',
         }}>
@@ -624,7 +662,7 @@ export default function VisualCard({
           position: 'absolute',
           fontSize: '13px',
           fontWeight: 700,
-          opacity: isCardHovered ? 1 : 0,
+          opacity: badgeHoverActive ? 1 : 0,
           transition: 'opacity 0.15s',
           pointerEvents: 'none',
           lineHeight: 1,
@@ -632,6 +670,129 @@ export default function VisualCard({
           ✓
         </span>
       </div>
+
+      {/* Touch edit bar — slim, revealed by tapping the qty badge. Full parity
+          with the desktop hover overlay (owned toggle, owned/qty steppers with
+          tap-to-edit numbers, remove). Always mounted so number inputs commit
+          onBlur; visibility is toggled via classes. Touch only. */}
+      {isTouch && (
+        <div
+          onClick={(e) => e.stopPropagation()}
+          className={`absolute bottom-0 left-0 right-0 z-[45] flex flex-wrap items-center justify-center gap-1.5 px-1.5 py-2 rounded-b-xl bg-gradient-to-t from-black/90 via-black/80 to-transparent transition-all duration-200 ${
+            barOpen ? "opacity-100 pointer-events-auto translate-y-0" : "opacity-0 pointer-events-none translate-y-2"
+          }`}
+        >
+          {/* Owned toggle */}
+          <button
+            onClick={(e) => { e.stopPropagation(); onToggleIsOwned(card.id); }}
+            aria-label={card.isOwned ? "Unmark as owned" : "Mark as owned"}
+            className={`w-7 h-7 rounded-full flex items-center justify-center text-sm font-bold border shrink-0 transition-colors ${
+              card.isOwned
+                ? isFullyOwned
+                  ? "bg-emerald-500 border-transparent text-white"
+                  : "bg-emerald-700 border-emerald-400/50 text-white"
+                : "bg-white/5 border-white/25 text-neutral-400"
+            }`}
+          >
+            ✓
+          </button>
+
+          {/* Owned stepper */}
+          <div className="flex items-center gap-1 shrink-0">
+            <button
+              onClick={(e) => { e.stopPropagation(); onUpdateOwnedQty(card.id, Math.max(0, card.ownedQty - 1)); }}
+              aria-label="Decrease owned"
+              className="w-7 h-7 rounded-full flex items-center justify-center bg-white/10 border border-white/20 text-neutral-100 active:bg-white/25 transition-colors"
+            >
+              <Minus className="w-3.5 h-3.5" />
+            </button>
+            {isOwnedEditing ? (
+              <input
+                type="text"
+                value={ownedEditValue}
+                onChange={(e) => setOwnedEditValue(e.target.value)}
+                onFocus={(e) => e.target.select()}
+                onBlur={() => { if (isOwnedEscaping.current) { isOwnedEscaping.current = false; return; } commitOwnedEdit(); }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") { e.preventDefault(); commitOwnedEdit(); }
+                  if (e.key === "Escape") { isOwnedEscaping.current = true; setIsOwnedEditing(false); }
+                }}
+                onClick={(e) => e.stopPropagation()}
+                className="w-7 text-center text-xs font-bold bg-white/10 border border-blue-500 rounded text-emerald-400 outline-none tabular-nums"
+                autoFocus
+              />
+            ) : (
+              <button
+                onClick={(e) => { e.stopPropagation(); startOwnedEdit(); }}
+                className="w-7 text-center text-xs font-bold tabular-nums"
+                style={{ color: ownedNumColor }}
+              >
+                {card.ownedQty}
+              </button>
+            )}
+            <button
+              onClick={(e) => { e.stopPropagation(); onUpdateOwnedQty(card.id, card.ownedQty + 1); }}
+              aria-label="Increase owned"
+              className="w-7 h-7 rounded-full flex items-center justify-center bg-white/10 border border-white/20 text-neutral-100 active:bg-white/25 transition-colors"
+            >
+              <Plus className="w-3.5 h-3.5" />
+            </button>
+          </div>
+
+          <span className="text-neutral-500 text-xs select-none">/</span>
+
+          {/* Qty stepper */}
+          <div className="flex items-center gap-1 shrink-0">
+            <button
+              onClick={(e) => { e.stopPropagation(); onUpdateQuantity(card.id, -1); }}
+              aria-label="Decrease quantity"
+              className="w-7 h-7 rounded-full flex items-center justify-center bg-white/10 border border-white/20 text-neutral-100 active:bg-white/25 transition-colors"
+            >
+              <Minus className="w-3.5 h-3.5" />
+            </button>
+            {isEditing ? (
+              <input
+                type="text"
+                value={editValue}
+                onChange={(e) => setEditValue(e.target.value)}
+                onFocus={(e) => e.target.select()}
+                onBlur={() => { if (isEscaping.current) { isEscaping.current = false; return; } commitEdit(); }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") { e.preventDefault(); commitEdit(); }
+                  if (e.key === "Escape") { isEscaping.current = true; setIsEditing(false); }
+                }}
+                onClick={(e) => e.stopPropagation()}
+                className="w-7 text-center text-xs font-bold bg-white/10 border border-blue-500 rounded text-white outline-none tabular-nums"
+                autoFocus
+              />
+            ) : (
+              <button
+                onClick={(e) => { e.stopPropagation(); startEdit(); }}
+                className="w-7 text-center text-xs font-bold tabular-nums"
+                style={{ color: overCopyLimit ? '#f87171' : '#e5e5e5' }}
+              >
+                {card.quantity}
+              </button>
+            )}
+            <button
+              onClick={(e) => { e.stopPropagation(); onUpdateQuantity(card.id, 1); }}
+              aria-label="Increase quantity"
+              className="w-7 h-7 rounded-full flex items-center justify-center bg-white/10 border border-white/20 text-neutral-100 active:bg-white/25 transition-colors"
+            >
+              <Plus className="w-3.5 h-3.5" />
+            </button>
+          </div>
+
+          {/* Remove */}
+          <button
+            onClick={(e) => { e.stopPropagation(); onRemove(card.id); }}
+            aria-label="Remove card"
+            className="w-7 h-7 rounded-full flex items-center justify-center bg-white/5 border border-white/20 text-neutral-300 active:bg-red-500/30 active:text-red-400 transition-colors shrink-0"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      )}
 
       {/* Price badge — stays visible, green when fully owned */}
       <div
@@ -643,7 +804,8 @@ export default function VisualCard({
           backdropFilter: 'blur(8px)',
           WebkitBackdropFilter: 'blur(8px)',
           color: price ? '#e5e5e5' : undefined,
-          opacity: price ? undefined : 0.45,
+          opacity: isTouch && barOpen ? 0 : price ? undefined : 0.45,
+          pointerEvents: isTouch && barOpen ? 'none' : undefined,
           fontSize: badgeSize.fontSize,
           fontWeight: 600,
           fontVariantNumeric: 'tabular-nums',

--- a/src/components/workspace/Workspace.tsx
+++ b/src/components/workspace/Workspace.tsx
@@ -581,8 +581,8 @@ export default function Workspace({ pendingImport, processImport, cancelImport, 
                 aspect-[2.5/3.5] w-full
               "
             >
-              <span className="text-base leading-none">+</span>
-              <span className="text-[8px] text-center leading-tight px-1.5">
+              <span className="text-lg leading-none">+</span>
+              <span className="text-xs text-center leading-tight px-1.5">
                 Add your first card
               </span>
             </div>
@@ -593,7 +593,7 @@ export default function Workspace({ pendingImport, processImport, cancelImport, 
               ([cat, cards]) =>
                 cards.length > 0 && (
                   <div key={cat}>
-                    <h3 className="text-[10px] font-bold text-content-muted uppercase tracking-widest mb-4 ml-1">
+                    <h3 className="text-[11px] font-bold text-content-muted uppercase tracking-widest mb-4 ml-1">
                       {cat} ({cards.reduce((s, c) => s + c.quantity, 0)})
                     </h3>
                     {viewMode === "visual" ? (

--- a/src/components/workspace/WorkspaceToolbar.tsx
+++ b/src/components/workspace/WorkspaceToolbar.tsx
@@ -155,7 +155,7 @@ export default function WorkspaceToolbar({
                 setFormatPickerDir((window.innerHeight - rect.bottom) > rect.top ? "down" : "up");
                 setFormatPickerOpen(!formatPickerOpen);
               }}
-              className="text-[10px] font-medium text-blue-400 bg-blue-400/10 border border-blue-400/20 px-1.5 py-0.5 rounded-full cursor-pointer hover:bg-blue-400/20 transition-colors select-none"
+              className="text-[11px] font-medium text-blue-400 bg-blue-400/10 border border-blue-400/20 px-2 py-1 rounded-full cursor-pointer hover:bg-blue-400/20 transition-colors select-none"
             >
               Standard
             </span>
@@ -167,7 +167,7 @@ export default function WorkspaceToolbar({
                 setFormatPickerDir((window.innerHeight - rect.bottom) > rect.top ? "down" : "up");
                 setFormatPickerOpen(!formatPickerOpen);
               }}
-              className="text-[10px] font-medium text-yellow-400 bg-yellow-400/10 border border-yellow-400/20 px-1.5 py-0.5 rounded-full cursor-pointer hover:bg-yellow-400/20 transition-colors select-none"
+              className="text-[11px] font-medium text-yellow-400 bg-yellow-400/10 border border-yellow-400/20 px-2 py-1 rounded-full cursor-pointer hover:bg-yellow-400/20 transition-colors select-none"
             >
               Commander
             </span>
@@ -179,7 +179,7 @@ export default function WorkspaceToolbar({
                 setFormatPickerDir((window.innerHeight - rect.bottom) > rect.top ? "down" : "up");
                 setFormatPickerOpen(!formatPickerOpen);
               }}
-              className="text-[10px] font-medium text-content-muted bg-neutral-500/10 border border-neutral-500/20 px-1.5 py-0.5 rounded-full cursor-pointer hover:bg-neutral-500/20 transition-colors select-none"
+              className="text-[11px] font-medium text-content-muted bg-neutral-500/10 border border-neutral-500/20 px-2 py-1 rounded-full cursor-pointer hover:bg-neutral-500/20 transition-colors select-none"
             >
               Freeform
             </span>
@@ -242,14 +242,14 @@ export default function WorkspaceToolbar({
       <button
         onClick={() => setMobileToolsOpen(true)}
         aria-label="Deck tools"
-        className="md:hidden flex items-center justify-center gap-1.5 h-9 px-3 shrink-0 bg-surface-base border border-line-subtle rounded-lg text-xs font-bold text-content-tertiary hover:text-content-primary hover:bg-surface-raised transition-colors shadow-sm"
+        className="md:hidden flex items-center justify-center gap-1.5 h-11 px-4 shrink-0 bg-surface-base border border-line-subtle rounded-lg text-sm font-bold text-content-tertiary hover:text-content-primary hover:bg-surface-raised transition-colors shadow-sm"
       >
         <SlidersHorizontal className="w-4 h-4" />
         <span>Tools</span>
       </button>
 
       {/* Right: simulator + main/side + sort/group/view (desktop only) */}
-      <div className="hidden md:flex items-center gap-2 h-8 shrink-0">
+      <div className="hidden md:flex items-center gap-2 h-9 shrink-0">
         <button
           onClick={onOpenSampleHand}
           className="flex items-center gap-2 h-full px-3 bg-surface-base border border-line-subtle rounded-lg text-xs font-bold text-content-tertiary hover:text-content-primary hover:bg-surface-raised transition-colors shadow-sm"
@@ -289,7 +289,7 @@ export default function WorkspaceToolbar({
         {/* Sort / Group / View */}
         <div className="flex items-center h-full bg-surface-base p-0.5 rounded-lg border border-line-subtle space-x-0.5 shadow-sm">
           <div className="flex items-center px-2 border-r border-line-subtle h-full gap-1">
-            <ArrowUpDown className="w-3 h-3 text-content-muted shrink-0" />
+            <ArrowUpDown className="w-4 h-4 text-content-muted shrink-0" />
             <select
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value as SortBy)}
@@ -304,19 +304,19 @@ export default function WorkspaceToolbar({
               <button
                 onClick={() => setSortDir(sortDir === "asc" ? "desc" : "asc")}
                 disabled={sortBy === "original"}
-                className={`flex items-center justify-center w-5 h-5 rounded transition-colors ${
+                className={`flex items-center justify-center w-7 h-7 rounded transition-colors ${
                   sortBy === "original"
                     ? "text-content-disabled cursor-not-allowed"
                     : "text-content-tertiary hover:text-content-primary"
                 }`}
               >
                 {sortDir === "asc" ? (
-                  <ArrowUp className="w-3 h-3" />
+                  <ArrowUp className="w-4 h-4" />
                 ) : (
-                  <ArrowDown className="w-3 h-3" />
+                  <ArrowDown className="w-4 h-4" />
                 )}
               </button>
-              <span className="absolute bottom-full mb-1.5 left-1/2 -translate-x-1/2 px-2 py-1 bg-surface-raised border border-line-default text-content-heading text-[9px] font-bold uppercase tracking-wider rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-normal max-w-xs z-50">
+              <span className="absolute bottom-full mb-1.5 left-1/2 -translate-x-1/2 px-2 py-1 bg-surface-raised border border-line-default text-content-heading text-[11px] font-bold uppercase tracking-wider rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-normal max-w-xs z-50">
                 {sortDir === "asc" ? "Sort ascending" : "Sort descending"}
               </span>
             </div>
@@ -331,9 +331,9 @@ export default function WorkspaceToolbar({
                   : "text-content-muted hover:text-content-secondary border border-transparent"
               }`}
             >
-              <Layout className="w-3.5 h-3.5" />
+              <Layout className="w-4 h-4" />
             </button>
-            <span className="absolute top-full mt-2 px-2 py-1 bg-surface-raised border border-line-default text-content-heading text-[9px] font-bold uppercase tracking-wider rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-normal max-w-xs z-50">
+            <span className="absolute top-full mt-2 px-2 py-1 bg-surface-raised border border-line-default text-content-heading text-[11px] font-bold uppercase tracking-wider rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-normal max-w-xs z-50">
               Toggle Type Groups
             </span>
           </div>
@@ -353,9 +353,9 @@ export default function WorkspaceToolbar({
                   : "text-content-muted hover:text-content-secondary border border-transparent"
               }`}
             >
-              <LayoutGrid className="w-3.5 h-3.5" />
+              <LayoutGrid className="w-4 h-4" />
             </button>
-            <span className="absolute top-full mt-2 px-2 py-1 bg-surface-raised border border-line-default text-content-heading text-[9px] font-bold uppercase tracking-wider rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-normal max-w-xs z-50">
+            <span className="absolute top-full mt-2 px-2 py-1 bg-surface-raised border border-line-default text-content-heading text-[11px] font-bold uppercase tracking-wider rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-normal max-w-xs z-50">
               Grid View
             </span>
           </div>
@@ -369,9 +369,9 @@ export default function WorkspaceToolbar({
                   : "text-content-muted hover:text-content-secondary border border-transparent"
               }`}
             >
-              <List className="w-3.5 h-3.5" />
+              <List className="w-4 h-4" />
             </button>
-            <span className="absolute top-full mt-2 px-2 py-1 bg-surface-raised border border-line-default text-content-heading text-[9px] font-bold uppercase tracking-wider rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-normal max-w-xs z-50">
+            <span className="absolute top-full mt-2 px-2 py-1 bg-surface-raised border border-line-default text-content-heading text-[11px] font-bold uppercase tracking-wider rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-normal max-w-xs z-50">
               List View
             </span>
           </div>

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,10 +1,16 @@
 // Keep in sync with `Current Version` in CLAUDE.md and CHANGELOG.md.
 // Three files change together on every version bump.
-export const APP_VERSION = "1.26.0";
+export const APP_VERSION = "1.27.0";
 
 // Each entry is an array of bullet points — one string per item.
 // New versions should follow this same format.
 export const CHANGELOG: Record<string, string[]> = {
+  "1.27.0": [
+    "Feature: you can now edit cards in the visual (grid) view on a touch tablet. The quantity/owned controls used to live in a panel that only appeared on mouse-hover, so on an iPad they were unreachable. Tap the quantity badge on a card and a slim bar slides up with everything the desktop has — mark-owned toggle, owned and quantity steppers (tap the number to type it), and remove.",
+    "Enhancement: the bar prioritizes the card art — it's a thin strip along the bottom, not the big panel that covered nearly half the card, and it only appears when you ask for it. Tap the art, tap elsewhere, or tap the badge again to dismiss it.",
+    "Enhancement: in Commander decks, the 'set as commander/partner' crown is now an always-visible corner tap on touch instead of a hover-only control.",
+    "Chore: desktop is unchanged — the hover overlay behaves exactly as before; the new tap-to-reveal bar is touch-only, driven by a shared (hover: none) check.",
+  ],
   "1.26.0": [
     "Feature: site-wide touch & sizing pass — one unified, finger-friendly scale across every screen (desktop included). Tiny hardcoded text (8–10px) is gone: nothing renders below 11px anymore, and primary content like deck names, card rows, and toolbar labels stepped up to legible sizes.",
     "Fix: list-view card controls work on touch now — the quantity/owned steppers, the owned ✓ toggle, the remove ✕, and the search 'add' button were hidden until mouse-hover, so on an iPad they never appeared and were impossible to tap. They're now always visible, enlarged to ~28px with real icons (no more 6px glyphs).",

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,10 +1,17 @@
 // Keep in sync with `Current Version` in CLAUDE.md and CHANGELOG.md.
 // Three files change together on every version bump.
-export const APP_VERSION = "1.25.0";
+export const APP_VERSION = "1.26.0";
 
 // Each entry is an array of bullet points — one string per item.
 // New versions should follow this same format.
 export const CHANGELOG: Record<string, string[]> = {
+  "1.26.0": [
+    "Feature: site-wide touch & sizing pass — one unified, finger-friendly scale across every screen (desktop included). Tiny hardcoded text (8–10px) is gone: nothing renders below 11px anymore, and primary content like deck names, card rows, and toolbar labels stepped up to legible sizes.",
+    "Fix: list-view card controls work on touch now — the quantity/owned steppers, the owned ✓ toggle, the remove ✕, and the search 'add' button were hidden until mouse-hover, so on an iPad they never appeared and were impossible to tap. They're now always visible, enlarged to ~28px with real icons (no more 6px glyphs).",
+    "Enhancement: standalone buttons across the chrome (sidebar rail, mobile menu/close, settings back, simulator close, deck-tools rows, search clear) are now 44px touch targets per Apple/Android guidance; chips, filter controls, format badges, and table rows gained breathing room.",
+    "Enhancement: home deck covers are larger (120×168) with readable titles; added an explicit iPad/notch-safe viewport (viewport-fit=cover). The new sizing standard is documented in docs/ARCHITECTURE.md so future UI conforms instead of drifting.",
+    "Note: the visual (grid) card editing overlay still reveals its controls on hover, so inline editing there remains pointer-oriented — a tap-to-reveal interaction for grid tiles is the planned follow-up.",
+  ],
   "1.25.0": [
     "Feature: deck controls are now reachable on mobile — the dense toolbar control block (Simulator, Main/Side, Sort, Group, card size, Grid/List) was wider than a phone screen and overflowed off the right edge with no way to reach it. Below 768px it now collapses into a single 'Tools' button that opens a bottom sheet with all of those controls as full-width, finger-sized rows.",
     "Enhancement: the bottom sheet slides up from the bottom over a dimmed backdrop (tap the backdrop or the X to close); the Simulator row closes the sheet and opens the simulator modal. Card size uses a touch-friendly XS–XL segmented control inside the sheet (the desktop slider is pointer-only).",

--- a/src/hooks/useIsTouch.ts
+++ b/src/hooks/useIsTouch.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+// True on devices without a hover-capable pointer (touch phones/tablets).
+// Single source of truth for the `(hover: none)` check used across the app —
+// drives touch-specific affordances (e.g. tap-to-reveal controls) while
+// leaving pointer/hover behaviour untouched.
+export function useIsTouch(): boolean {
+  const [isTouch, setIsTouch] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(hover: none)");
+    const update = () => setIsTouch(mq.matches);
+    update();
+    mq.addEventListener?.("change", update);
+    return () => mq.removeEventListener?.("change", update);
+  }, []);
+  return isTouch;
+}


### PR DESCRIPTION
## Summary

Makes the app usable on a touch tablet (iPad), in two stacked versions on this branch:

### v1.26.0 — Site-wide touch & sizing pass
One unified, finger-friendly scale across desktop and touch (no responsive split):
- 11px text floor (every `text-[8/9/10px]` promoted by role)
- 44px standalone chrome buttons (`h-11 w-11`)
- Dense inline controls (list-view qty/owned steppers, owned ✓ toggle, row remove ✕, search-results add) un-gated from `opacity-0 group-hover` — they were unreachable on touch — now always visible at ~28px with real 16px `lucide` icons
- Explicit `viewport-fit=cover` in `layout.tsx`
- Standard documented in `docs/ARCHITECTURE.md` → **Touch & Sizing System**

### v1.27.0 — Grid-view editing on touch
The follow-up flagged in 1.26.0. The visual (grid) tile's edit controls lived in a `group-hover` slide-up overlay — unreachable on touch, and ~45% art coverage when shown.
- New **`useIsTouch()`** hook (`matchMedia("(hover: none)")`) as the single source of truth; `FindByNameBar`'s duplicated inline detection now uses it
- On touch, tapping the always-on **qty badge** reveals a **slim bottom bar** at full desktop parity: owned ✓ toggle, owned + qty steppers (tap-to-edit numbers), remove. Always mounted so inputs commit `onBlur`; dismissed by tapping the art, tapping outside the card, or re-tapping the badge; badge + price pill hide while open
- Commander **crown** un-gated to an always-visible **corner tap** on touch
- Emulated-hover suppressed on touch so the badge stays a stable qty/reveal chip (`badgeHoverActive = !isTouch && isCardHovered`)
- **Desktop / pointer behaviour is unchanged** — everything new is gated behind `isTouch`

## Verification
- `tsc --noEmit` clean
- Lint problem count unchanged from baseline (73 — zero new issues)
- Not yet smoke-tested on a real device; the production build's only blocker in the sandbox is the network-restricted Google Fonts (Inter) fetch, unrelated to these changes

https://claude.ai/code/session_01Qro1a7MzwqY79pYfic64Xu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qro1a7MzwqY79pYfic64Xu)_