### PR TITLE
Undoable deck / sideboard deletion (v1.29.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.29.0] — Undoable deck deletion
+
+Completes the undo-on-delete pass from 1.28.0 (which covered cards). Deleting a deck or its sideboard from the sidebar's deck-row ✕ menu was silent and irreversible — now both fire the 4s `showUndoToast`.
+
+### Added
+- **Undo on deck / sideboard deletion** — `SidebarDecksTab.deleteDeckWithUndo` / `deleteSideboardWithUndo` snapshot the full `decks` list + active deck id before deleting, then restore the exact prior state on Undo via `replaceAllDecks(snapshot)` + `setActiveDeckId(prevActiveId)`. Cross-platform (the deletion UI is the same sidebar menu on desktop and mobile). Closes the BACKLOG undo-for-destructive-actions item.
+
+### Changed
+- `showUndoToast` is now threaded `page.tsx → Sidebar → SidebarDecksTab`
+
+---
+
 ## [1.28.0] — Undoable card removal + safer touch delete
 
 Follow-up to the 1.27.0 touch edit bar. The bar's remove (✕) sat next to the steppers and read like a "close" button — tapping it to dismiss the bar deleted the card instead, with no feedback or undo. Root cause: `removeCard` mutated the deck silently (no toast wired in), and the destructive ✕ was placed inside the bar. Both fixed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,9 @@ Default to direct work. Tier up only when the change earns it.
 
 ## Current Version
 
-`v1.28.0` — Undoable card removal + safer touch delete (1.27.0 follow-up). Deleting a card now shows a 4s Undo toast that restores it at its original position (`Workspace.removeCard` / `removeSideboardCard` → `showUndoToast`); covers grid + list, desktop + touch. The grid touch bar's ✕ moved out of the bar to the top-right corner (its desktop-hover spot), shown only while the bar is open — it was too easy to tap ✕ to dismiss the bar and delete by accident. Dismiss the bar by tapping the art / outside instead.
+`v1.29.0` — Undoable deck deletion. The sidebar deck-row ✕ menu's "Delete Deck" / "Delete Sideboard" now show a 4s Undo toast that restores the exact prior state (`SidebarDecksTab.deleteDeckWithUndo` / `deleteSideboardWithUndo` → snapshot `decks` + active id → `replaceAllDecks` + `setActiveDeckId`). `showUndoToast` threaded `page.tsx → Sidebar → SidebarDecksTab`. Completes the undo-on-delete pass (cards in 1.28.0, decks now).
+
+Prior: `v1.28.0` — Undoable card removal + safer touch delete (1.27.0 follow-up). Deleting a card now shows a 4s Undo toast that restores it at its original position (`Workspace.removeCard` / `removeSideboardCard` → `showUndoToast`); covers grid + list, desktop + touch. The grid touch bar's ✕ moved out of the bar to the top-right corner (its desktop-hover spot), shown only while the bar is open — it was too easy to tap ✕ to dismiss the bar and delete by accident. Dismiss the bar by tapping the art / outside instead.
 
 Prior: `v1.27.0` — Grid-view editing on touch (the 1.26.0 follow-up). On touch only (`useIsTouch` → `(hover: none)`), tapping the always-on quantity badge reveals a slim bottom bar (owned ✓ toggle, owned + qty steppers with tap-to-edit numbers). The Commander crown becomes an always-visible corner tap on touch. Desktop/pointer behaviour unchanged. Pattern in `docs/ARCHITECTURE.md` → **Touch & Sizing System** (Grid tile editing).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -248,7 +248,9 @@ Unified, touch-first sizing applied across all surfaces (desktop included — on
 
 **Grid tile editing (`VisualCard`, deck mode).** The desktop edit surface is a `group-hover` slide-up overlay (name/type/steppers) — unreachable on touch and, if naively tap-revealed, it covers ~45% of the art. On touch (`useIsTouch`) the model is different: the always-on **qty badge is a reveal trigger** — tapping it opens a slim, full-width bottom bar with the owned ✓ toggle and the owned & qty steppers (tap-to-edit numbers). The bar is always mounted (visibility toggled via classes) so number inputs commit `onBlur`. It's dismissed by tapping the art, tapping outside the card (`pointerdown` listener gated on `barOpen`), or re-tapping the badge; the badge and price pill hide while it's open. The commander crown is un-gated to an always-visible corner tap. **Remove is deliberately *not* in the bar** — it's the top-right corner × (desktop: hover-gated; touch: shown while the bar is open), kept clear of the steppers so it's never mistaken for a "close" button. Desktop hover is untouched — everything new is gated behind `isTouch`, and the badge's emulated-hover visuals are suppressed on touch (`badgeHoverActive = !isTouch && isCardHovered`).
 
-**Card removal is undoable.** `Workspace.removeCard` / `removeSideboardCard` snapshot the card's index (+ commander status) and fire `showUndoToast` (4s, inline Undo) which re-inserts it where it was — covers grid *and* list, desktop *and* touch.
+**Destructive actions are undoable** (4s `showUndoToast`, inline Undo):
+- **Card removal** — `Workspace.removeCard` / `removeSideboardCard` snapshot the card's index (+ commander status) and re-insert it where it was; covers grid *and* list, desktop *and* touch.
+- **Deck / sideboard deletion** — `SidebarDecksTab.deleteDeckWithUndo` / `deleteSideboardWithUndo` snapshot the full `decks` list + active id, then restore via `replaceAllDecks(snapshot)` + `setActiveDeckId(prevActiveId)` (the latter corrects `replaceAllDecks`'s default of activating `decks[0]`). `showUndoToast` is threaded `page.tsx → Sidebar → SidebarDecksTab`.
 
 ### React Patterns
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -34,7 +34,7 @@ Items from v1.19.x carry-forwards and new additions:
 - [ ] **bug** | **[high]** | Price "N/A" fallback — cards showing N/A have a TCGPlayer price; fallback should attempt a lookup or show a more accurate placeholder
 - [ ] **enhancement** | Search: highlight newly added cards after FindByNameBar add — when closing the preview after adding, briefly highlight or scroll to the new card in the deck
 - [ ] **enhancement** | Copy card name to clipboard — click card name in modal to copy ⚠️ needs design
-- [ ] **enhancement** | Undo for destructive actions — ✅ card delete done (v1.28.0, grid + list); **deck delete** still pending
+- [x] **enhancement** | Undo for destructive actions — ✅ card delete (v1.28.0, grid + list) + deck/sideboard delete (v1.29.0)
 - [ ] **enhancement** | CardModal art swap: option to confirm swap or add as new card instead ⚠️ needs design
 - [ ] **enhancement** | Import modal — add "Paste from clipboard" button as an alternative to file import
 - [ ] **enhancement** | Simulator modal has no view mode toggle — consider adding compact list view inside modal for larger decks

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -407,6 +407,7 @@ export default function Dashboard() {
         onOpenSettings={openSettings}
         showSettings={showSettings}
         onCloseSettings={() => setShowSettings(false)}
+        showUndoToast={showUndoToast}
         onGoHome={() => { setActiveDeckId(null); setShowSettings(false); setMobileSidebarOpen(false); }}
         isOnHomeScreen={!activeDeck && !showSettings}
         mobileOpen={mobileSidebarOpen}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -17,9 +17,10 @@ interface Props {
   isOnHomeScreen: boolean;
   mobileOpen: boolean;
   onMobileClose: () => void;
+  showUndoToast: (msg: string, onUndo: () => void) => void;
 }
 
-export default function Sidebar({ onImport, onExport, isImporting, onOpenSettings, onCloseSettings, onGoHome, isOnHomeScreen, mobileOpen, onMobileClose }: Props) {
+export default function Sidebar({ onImport, onExport, isImporting, onOpenSettings, onCloseSettings, onGoHome, isOnHomeScreen, mobileOpen, onMobileClose, showUndoToast }: Props) {
   const [collapsed, setCollapsed] = useState(false);
   const [isDesktop, setIsDesktop] = useState(false);
 
@@ -114,6 +115,7 @@ export default function Sidebar({ onImport, onExport, isImporting, onOpenSetting
               isImporting={isImporting}
               onCloseSettings={onCloseSettings}
               onNavigate={onMobileClose}
+              showUndoToast={showUndoToast}
             />
           </div>
 

--- a/src/components/layout/SidebarDecksTab.tsx
+++ b/src/components/layout/SidebarDecksTab.tsx
@@ -15,6 +15,7 @@ interface Props {
   // Called on any in-sidebar navigation (deck select, sideboard view, new deck)
   // so the mobile drawer can close itself.
   onNavigate?: () => void;
+  showUndoToast: (msg: string, onUndo: () => void) => void;
 }
 
 interface ConfirmDialogState {
@@ -23,7 +24,7 @@ interface ConfirmDialogState {
   targetFormat: DeckFormat;
 }
 
-export default function SidebarDecksTab({ onImport, onExport, isImporting, onCloseSettings, onNavigate }: Props) {
+export default function SidebarDecksTab({ onImport, onExport, isImporting, onCloseSettings, onNavigate, showUndoToast }: Props) {
   const {
     decks,
     activeDeck,
@@ -36,7 +37,32 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
     setDeckFormat,
     mergeSideboardIntoDeck,
     deleteSideboardForFormat,
+    replaceAllDecks,
   } = useDeckManager();
+
+  // Destructive deck/sideboard actions snapshot the full deck list + active id
+  // first, then fire an Undo toast that restores the exact prior state.
+  // `replaceAllDecks` resets the active deck to the first one, so we re-apply
+  // the snapshotted active id afterwards.
+  const deleteDeckWithUndo = (deckId: string, deckName: string) => {
+    const snapshot = decks.map((d) => ({ ...d }));
+    const prevActiveId = activeDeck?.id ?? null;
+    deleteDeck(deckId);
+    showUndoToast(`Deleted ${deckName}`, () => {
+      replaceAllDecks(snapshot);
+      setActiveDeckId(prevActiveId);
+    });
+  };
+
+  const deleteSideboardWithUndo = (deckId: string, deckName: string) => {
+    const snapshot = decks.map((d) => ({ ...d }));
+    const prevActiveId = activeDeck?.id ?? null;
+    deleteSideboard(deckId);
+    showUndoToast(`Deleted ${deckName} sideboard`, () => {
+      replaceAllDecks(snapshot);
+      setActiveDeckId(prevActiveId);
+    });
+  };
 
   const { buyOnTCGPlayer, buyOnCardKingdom } = useDeckStats(activeDeck ?? null);
 
@@ -259,7 +285,7 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
                   >
                     <button
                       onClick={() => {
-                        deleteDeck(deck.id);
+                        deleteDeckWithUndo(deck.id, deck.name);
                         setOpenDeleteDropdownId(null);
                       }}
                       className="flex items-center gap-2 w-full text-left px-3 py-2.5 text-sm text-red-500 hover:bg-red-500/10 transition-colors"
@@ -269,7 +295,7 @@ export default function SidebarDecksTab({ onImport, onExport, isImporting, onClo
                     {hasSideboard && (
                       <button
                         onClick={() => {
-                          deleteSideboard(deck.id);
+                          deleteSideboardWithUndo(deck.id, deck.name);
                           setOpenDeleteDropdownId(null);
                         }}
                         className="flex items-center gap-2 w-full text-left px-3 py-2.5 text-sm text-red-500 hover:bg-red-500/10 transition-colors"

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,10 +1,13 @@
 // Keep in sync with `Current Version` in CLAUDE.md and CHANGELOG.md.
 // Three files change together on every version bump.
-export const APP_VERSION = "1.28.0";
+export const APP_VERSION = "1.29.0";
 
 // Each entry is an array of bullet points — one string per item.
 // New versions should follow this same format.
 export const CHANGELOG: Record<string, string[]> = {
+  "1.29.0": [
+    "Feature: deleting a deck is now undoable. The deck-row ✕ menu's 'Delete Deck' (and 'Delete Sideboard') now show a 4-second toast with an Undo button that puts the deck back exactly as it was. Completes the undo-on-delete pass started in 1.28.0 — now covers cards and decks.",
+  ],
   "1.28.0": [
     "Fix: removing a card is now undoable. Deleting a card (or sideboard card) shows a 4-second toast with an Undo button that puts it back exactly where it was — works in both grid and list views, on desktop and touch.",
     "Fix: on a touch tablet, the grid edit bar's delete (✕) moved out of the bar to the top-right corner of the card (the same spot it sits on desktop), and only shows while the bar is open. It was too easy to tap ✕ to dismiss the bar and delete the card by accident — now you dismiss by tapping the card art or anywhere outside, and the ✕ is clearly separated from the quantity controls.",


### PR DESCRIPTION
## Summary

Completes the undo-on-delete pass from #91 (which covered cards). Deleting a deck or its sideboard from the sidebar's deck-row ✕ menu was **silent and irreversible** — now both fire the existing 4s `showUndoToast`.

### Added
- **Undo on deck / sideboard deletion** — `SidebarDecksTab.deleteDeckWithUndo` / `deleteSideboardWithUndo` snapshot the full `decks` list + active deck id before deleting, then restore the exact prior state on Undo via `replaceAllDecks(snapshot)` + `setActiveDeckId(prevActiveId)` (the latter corrects `replaceAllDecks`'s default of activating `decks[0]`). Closes the BACKLOG undo-for-destructive-actions item.

### Changed
- `showUndoToast` threaded `page.tsx → Sidebar → SidebarDecksTab`

### Notes
- The deletion UI is the same sidebar menu on desktop and mobile, so the undo is cross-platform (not touch-gated).
- Single-level undo: the snapshot is the full deck list, so undoing restores exact prior state (position + active deck). The standard ~4s-window caveat applies (a concurrent change within the window would be overwritten on Undo).

## Verification
- `tsc --noEmit` clean
- Lint problem count unchanged from baseline (73)
- Not device-tested

https://claude.ai/code/session_01Qro1a7MzwqY79pYfic64Xu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qro1a7MzwqY79pYfic64Xu)_