### PR TITLE
fix: remove border from mobile Tools button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.30.2] — Tools button border fix
+
+### Changed
+- **Mobile "Tools" button is now borderless** (`WorkspaceToolbar.tsx`) — removed the `bg-surface-base`, `border border-line-subtle`, and `shadow-sm` so it's a plain `text-content-muted` / `hover:bg-surface-raised` icon button, matching the site's other chrome icon buttons (hamburger menu, sidebar rail, search-bar menu). The boxed look was inconsistent with the rest of the UI.
+
+---
+
 ## [1.30.1] — Mobile toolbar & delete polish
 
 Two small mobile/touch UX tweaks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,9 @@ Default to direct work. Tier up only when the change earns it.
 
 ## Current Version
 
-`v1.30.1` — Mobile toolbar & delete polish. The mobile-only "Tools" button in `WorkspaceToolbar` is now icon-only (44px square, `SlidersHorizontal`, no label) to reclaim toolbar width. The grid card's touch remove (✕) in `VisualCard` — shown while the tap-to-edit bar is open — is now tinted red (`bg-red-900 text-red-300`) instead of neutral surface, since touch has no hover to signal the destructive action; desktop hover-to-red is unchanged.
+`v1.30.2` — Tools button border fix. The mobile "Tools" button in `WorkspaceToolbar` is now borderless — dropped `bg-surface-base border border-line-subtle shadow-sm` for a plain `text-content-muted` / `hover:bg-surface-raised` icon button, matching the site's other chrome icon buttons (hamburger, sidebar rail, search-bar menu). The boxed look was inconsistent.
+
+Prior: `v1.30.1` — Mobile toolbar & delete polish. The mobile-only "Tools" button in `WorkspaceToolbar` is now icon-only (44px square, `SlidersHorizontal`, no label) to reclaim toolbar width. The grid card's touch remove (✕) in `VisualCard` — shown while the tap-to-edit bar is open — is now tinted red (`bg-red-900 text-red-300`) instead of neutral surface, since touch has no hover to signal the destructive action; desktop hover-to-red is unchanged.
 
 Prior: `v1.30.0` — Light theme + match system. Adds a third palette, **Light** (`[data-theme="light"]`, warm light — the daylight counterpart to Warm Stone), and a **System** preference (now the default) that follows the OS: dark OS → Warm Stone, light OS → Light, updating live on OS flip. Theme logic centralized in `src/lib/theme.ts` (preference `system|warm-stone|zed-dark|light` vs. resolved theme); `mtg-theme` now stores the preference (absent = system). The `layout.tsx` no-flash init script resolves `system` before first paint and listens for OS changes. Picker in `SettingsView` is now four swatches (`THEME_OPTIONS`). Removed the dead `prefers-color-scheme` CSS block (resolution is JS-driven now). See `docs/ARCHITECTURE.md` → **Design Token System**.
 

--- a/src/components/workspace/WorkspaceToolbar.tsx
+++ b/src/components/workspace/WorkspaceToolbar.tsx
@@ -243,7 +243,7 @@ export default function WorkspaceToolbar({
       <button
         onClick={() => setMobileToolsOpen(true)}
         aria-label="Deck tools"
-        className="md:hidden flex items-center justify-center w-11 h-11 shrink-0 bg-surface-base border border-line-subtle rounded-lg text-content-tertiary hover:text-content-primary hover:bg-surface-raised transition-colors shadow-sm"
+        className="md:hidden flex items-center justify-center w-11 h-11 shrink-0 rounded-md text-content-muted hover:text-content-primary hover:bg-surface-raised transition-colors"
       >
         <SlidersHorizontal className="w-4 h-4" />
       </button>

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,10 +1,13 @@
 // Keep in sync with `Current Version` in CLAUDE.md and CHANGELOG.md.
 // Three files change together on every version bump.
-export const APP_VERSION = "1.30.1";
+export const APP_VERSION = "1.30.2";
 
 // Each entry is an array of bullet points — one string per item.
 // New versions should follow this same format.
 export const CHANGELOG: Record<string, string[]> = {
+  "1.30.2": [
+    "Fix: the mobile 'Tools' button no longer has a box around it — dropped the border, background, and shadow so it's a plain icon button matching the rest of the site's chrome (the hamburger menu, sidebar rail, etc.).",
+  ],
   "1.30.1": [
     "Enhancement: on mobile the deck toolbar's 'Tools' button is now icon-only (the sliders icon, no label) — frees up horizontal room in the toolbar.",
     "Enhancement: on touch, the card's remove (✕) button — the one that appears when you tap a card's quantity in grid view — is now tinted red instead of neutral white, so it reads clearly as the delete action.",


### PR DESCRIPTION
## Summary

Removes the border/background/shadow from the mobile "Tools" button so it matches the rest of the site's chrome icon buttons (v1.30.2).

The Tools button was using `bg-surface-base border border-line-subtle ... shadow-sm`, giving it a boxed look inconsistent with the site's other icon buttons (hamburger menu, sidebar rail, search-bar menu), which are plain `text-content-muted` / `hover:bg-surface-raised` borderless buttons. Now it follows the same convention.

Version bumped to **1.30.2** with matching `version.ts`, `CHANGELOG.md`, and `CLAUDE.md` updates.

https://claude.ai/code/session_01L8BXAjjGAmpeeX6w2GNDvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8BXAjjGAmpeeX6w2GNDvB)_