### PR TITLE
feat: list view on mobile — compact touch row + tap-to-edit (v1.31.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.31.0] — List view on mobile
+
+Brings the list (table) view to touch, the way the grid (visual) view was brought to touch in 1.27.0. The desktop list is a wide 7-column `table-fixed` (owned ✓, a dual owned/quantity stepper at `w-52`, name, type, mana, price, remove) totalling ~656px of fixed columns, with its steppers revealed on row-hover — so on a phone it overflowed off-screen and its controls were unreachable.
+
+### Added
+- **Compact touch row** (`ListCardTable.tsx`) — on touch (`useIsTouch()` → `(hover: none)`) each card renders as a 4-column row that fits a phone: owned ✓ toggle · name (with mana symbols + type line as a subline) · quantity chip · price. A fixed `<colgroup>` keeps the columns stable regardless of the first body row.
+- **Tap-to-expand edit sub-row** — tapping the quantity chip expands an inline control bar beneath the row with full parity: mark-owned toggle, owned stepper, quantity stepper (tap a number to type it), and a red remove (✕). Reuses the existing inline-edit state/handlers; mirrors the grid tile's tap-to-edit bar.
+- **Always-visible crown on touch** — in Commander decks the set-as-commander/partner crown is an always-visible per-row tap instead of hover-only. The crown's decision logic was factored into a shared `getCrownDecision()` helper.
+
+### Changed
+- The table now renders a touch `<colgroup>` and hides the desktop `<thead>` on touch; the body picks `renderTouchRow` vs. `renderRow` per `isTouch`.
+
+### Unchanged
+- Desktop (pointer) list view is byte-for-byte the same — the full 7-column hover table still renders via `renderRow`. The mobile/desktop split is driven entirely by the shared `(hover: none)` check.
+
+---
+
 ## [1.30.2] — Tools button border fix
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,9 @@ Default to direct work. Tier up only when the change earns it.
 
 ## Current Version
 
-`v1.30.2` — Tools button border fix. The mobile "Tools" button in `WorkspaceToolbar` is now borderless — dropped `bg-surface-base border border-line-subtle shadow-sm` for a plain `text-content-muted` / `hover:bg-surface-raised` icon button, matching the site's other chrome icon buttons (hamburger, sidebar rail, search-bar menu). The boxed look was inconsistent.
+`v1.31.0` — List view on mobile. The list (table) view now works on touch, mirroring the grid-view touch pass (1.27.0). The desktop list is a wide 7-column `table-fixed` (~656px of fixed columns) with hover-revealed steppers — unusable on a phone. On touch (`useIsTouch` → `(hover: none)`) `ListCardTable` renders a compact 4-column row (owned ✓ · name with mana+type subline · qty chip · price) via a new `renderTouchRow`; tapping the qty chip expands an inline edit sub-row (owned toggle, owned/qty steppers with tap-to-edit numbers, red remove ✕). A fixed `<colgroup>` keeps columns stable; the desktop `<thead>` is hidden on touch. The commander crown becomes an always-visible per-row tap (shared `getCrownDecision` helper). Desktop (`renderRow`) is unchanged. See `docs/ARCHITECTURE.md` → **Touch & Sizing System**.
+
+Prior: `v1.30.2` — Tools button border fix. The mobile "Tools" button in `WorkspaceToolbar` is now borderless — dropped `bg-surface-base border border-line-subtle shadow-sm` for a plain `text-content-muted` / `hover:bg-surface-raised` icon button, matching the site's other chrome icon buttons (hamburger, sidebar rail, search-bar menu). The boxed look was inconsistent.
 
 Prior: `v1.30.1` — Mobile toolbar & delete polish. The mobile-only "Tools" button in `WorkspaceToolbar` is now icon-only (44px square, `SlidersHorizontal`, no label) to reclaim toolbar width. The grid card's touch remove (✕) in `VisualCard` — shown while the tap-to-edit bar is open — is now tinted red (`bg-red-900 text-red-300`) instead of neutral surface, since touch has no hover to signal the destructive action; desktop hover-to-red is unchanged.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -222,7 +222,7 @@ Any navigation action (tab click, deck name click, home button) **must** call `o
 
 ### Touch & Sizing System
 
-<!-- Last updated: v1.26.0 -->
+<!-- Last updated: v1.31.0 -->
 
 Unified, touch-first sizing applied across all surfaces (desktop included — one comfortable scale, no responsive split). Established in v1.26.0 to kill ad-hoc per-component values. **When adding UI, conform to these floors instead of inventing new sizes.**
 
@@ -250,6 +250,8 @@ Unified, touch-first sizing applied across all surfaces (desktop included — on
 
 **Grid tile editing (`VisualCard`, deck mode).** The desktop edit surface is a `group-hover` slide-up overlay (name/type/steppers) — unreachable on touch and, if naively tap-revealed, it covers ~45% of the art. On touch (`useIsTouch`) the model is different: the always-on **qty badge is a reveal trigger** — tapping it opens a slim, full-width bottom bar with the owned ✓ toggle and the owned & qty steppers (tap-to-edit numbers). The bar is always mounted (visibility toggled via classes) so number inputs commit `onBlur`. It's dismissed by tapping the art, tapping outside the card (`pointerdown` listener gated on `barOpen`), or re-tapping the badge; the badge and price pill hide while it's open. The commander crown is un-gated to an always-visible corner tap. **Remove is deliberately *not* in the bar** — it's the top-right corner × (desktop: hover-gated; touch: shown while the bar is open), kept clear of the steppers so it's never mistaken for a "close" button. Desktop hover is untouched — everything new is gated behind `isTouch`, and the badge's emulated-hover visuals are suppressed on touch (`badgeHoverActive = !isTouch && isCardHovered`).
 
+**List row editing (`ListCardTable`, deck mode).** The desktop row is a 7-column `table-fixed` (owned ✓ · `w-52` dual owned/qty stepper · name · type · mana · price · remove) ≈ 656px of fixed columns, with steppers revealed on row-hover — it overflows a phone and its controls are unreachable on touch. On touch (`useIsTouch`) the table swaps to a compact 4-column layout via `renderTouchRow`: owned ✓ · name (mana symbols + type line as a subline) · **qty chip** · price. The qty chip is the **reveal trigger** — tapping it expands an inline edit sub-row (`<tr>` with a `colSpan` cell) holding the owned ✓ toggle, owned/qty steppers (tap-to-edit numbers, reusing the same `editingId`/`editingOwnedId` state), and a red remove ✕ at the right. A fixed `<colgroup>` pins the touch column widths (so the first body row being a pinned commander or group spacer can't skew them) and the desktop `<thead>` is hidden on touch. The commander crown is un-gated to an always-visible per-row tap, sharing the `getCrownDecision` helper with the (unchanged) desktop `renderRow`. Same philosophy as the grid tile: everything new is gated behind `isTouch`; the pointer table is untouched.
+
 **Destructive actions are undoable** (4s `showUndoToast`, inline Undo):
 - **Card removal** — `Workspace.removeCard` / `removeSideboardCard` snapshot the card's index (+ commander status) and re-insert it where it was; covers grid *and* list, desktop *and* touch.
 - **Deck / sideboard deletion** — `SidebarDecksTab.deleteDeckWithUndo` / `deleteSideboardWithUndo` snapshot the full `decks` list + active id, then restore via `replaceAllDecks(snapshot)` + `setActiveDeckId(prevActiveId)` (the latter corrects `replaceAllDecks`'s default of activating `decks[0]`). `showUndoToast` is threaded `page.tsx → Sidebar → SidebarDecksTab`.
@@ -258,7 +260,7 @@ Unified, touch-first sizing applied across all surfaces (desktop included — on
 
 - `setCardRef(id)` — curried helper for card refs; inline `{ if(el) }` causes parse errors in JSX
 - `duplicate ))}` bug — caused by stacked `.map()` closings; always verify one closing per map
-- `table-fixed` on `ListCardTable` — prevents horizontal overflow
+- `table-fixed` on `ListCardTable` — prevents horizontal overflow on desktop; on touch a `<colgroup>` defines the compact 4-column widths (see Touch & Sizing System → List row editing)
 - Workspace scroll container uses `p-4 pb-20` (not `overflow-x-hidden`) — needed for tooltips, ring-offset, and badge overhang clearance
 - `contentEditable` abandoned for deck name input — use `size={Math.max(10, name.length)}`
 - **React 19 registers `onWheel` as passive** — `e.preventDefault()` inside a JSX `onWheel={...}` handler is silently ignored. Any wheel handler that needs to override default scroll (e.g. convert vertical wheel into horizontal `scrollLeft` inside an `overflow-y-auto` ancestor) must be attached natively with `addEventListener("wheel", handler, { passive: false })`. The `FindByNameBar` art strip uses a window-level listener delegated by `[data-art-strip]` selector (see line 35); v1.23.1 fixed the regression where the strip's wheel scroll silently broke after upgrading. Same caution applies to `onTouchStart`/`onTouchMove`

--- a/src/components/workspace/ListCardTable.tsx
+++ b/src/components/workspace/ListCardTable.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from "react";
 import { X, Minus, Plus } from "lucide-react";
 import { DeckCard, ScryfallCard } from "@/types";
+import { useIsTouch } from "@/hooks/useIsTouch";
 import { DeckFormat, getFormatRules, getCardWarnings, isEligibleCommander, isVehicleOrSpacecraftCommander, hasPartnerAbility } from "@/lib/formatRules";
 
 const COLOR_ORDER_L = ["W", "U", "B", "R", "G"];
@@ -123,6 +124,14 @@ export default function ListCardTable({
 }: ListCardTableProps) {
   const rules = getFormatRules(format);
 
+  // Touch: the desktop row is a wide 7-column table (steppers, type, mana, price)
+  // that overflows a phone and whose hover-revealed steppers are cramped. On
+  // touch we render a compact row (✓ · name+meta · qty chip · price) and reveal
+  // the full edit controls in an expanding sub-row when the qty chip is tapped —
+  // mirroring the grid tile's tap-to-edit bar. Pointer behaviour is untouched.
+  const isTouch = useIsTouch();
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
   // Row hover state for tint brightening
   const [hoveredRowId, setHoveredRowId] = useState<string | null>(null);
 
@@ -192,7 +201,39 @@ export default function ListCardTable({
 
   const isCommanderFormat = format === "commander";
   const COLUMN_COUNT = 7;
+  const TOUCH_COLUMN_COUNT = 4; // ✓ · name · qty · price
   const commanderCount = commanderIds?.length ?? 0;
+
+  // Pure crown decision (which action a non-commander card's crown performs).
+  // Shared by the touch row; the desktop row keeps its inline copy for the
+  // tooltip wiring. Returns null action when the card can't legally be set.
+  const getCrownDecision = (card: DeckCard) => {
+    const eligible = isEligibleCommander(card);
+    const cardHasPartner = hasPartnerAbility(card);
+    let crownLabel = "Set as Commander";
+    let crownAction: (() => void) | null = null;
+    let canAct = eligible;
+    if (commanderCount === 0) {
+      crownAction = eligible ? () => onAddCommander?.(card.id) : null;
+    } else if (commanderCount === 1) {
+      if (cardHasPartner && existingCommanderHasPartner) {
+        crownLabel = "Set as Partner";
+        crownAction = () => onAddCommander?.(card.id);
+        canAct = true;
+      } else {
+        crownAction = eligible ? () => onReplaceCommander?.(0, card.id) : null;
+      }
+    } else {
+      if (cardHasPartner) {
+        crownLabel = "Set as Partner";
+        crownAction = () => onReplaceCommander?.(1, card.id);
+        canAct = true;
+      } else {
+        crownAction = eligible ? () => onReplaceCommander?.(0, card.id) : null;
+      }
+    }
+    return { crownLabel, crownAction, canAct, eligible };
+  };
 
   // Separate out pinned commanders (leading cards that are commanders)
   const pinnedCommanders: DeckCard[] = [];
@@ -636,13 +677,328 @@ export default function ListCardTable({
     );
   };
 
+  // ── Touch row — compact, with a tap-to-expand edit sub-row ────────────────────
+  const renderTouchRow = (card: DeckCard, index: number, fromPinned = false) => {
+    const showGroupSpacer =
+      !fromPinned &&
+      !isGrouped &&
+      !!sortBy &&
+      (sortBy === "color" || sortBy === "mv") &&
+      index > 0 &&
+      getGroupKey(bodyCards[index - 1], sortBy) !== getGroupKey(card, sortBy);
+
+    const isFullyOwned = card.isOwned && card.quantity > 0 && card.ownedQty >= card.quantity;
+    const ownershipRatio = card.isOwned && card.quantity > 0 ? Math.min(card.ownedQty / card.quantity, 1) : 0;
+    const cellOpacity = card.quantity === 0 ? 0.3 : 1 - ownershipRatio * 0.5;
+    const cellGrayscale = card.quantity === 0 ? "grayscale" : "";
+    const nameColor = card.quantity === 0
+      ? "text-content-muted"
+      : isFullyOwned
+      ? "text-green-400"
+      : "text-neutral-100";
+
+    const extraQty = sideboardQtyMap?.get(card.name.toLowerCase()) ?? 0;
+    const isExempt =
+      card.type_line?.toLowerCase().includes("basic land") ||
+      card.oracle_text?.includes("A deck can have any number");
+    const combinedQty = card.quantity + extraQty;
+    const overCopyLimit = combinedQty >= rules.softWarnThreshold && !isExempt;
+
+    const isCommander1 = isCommanderFormat && card.id === commanderIds?.[0];
+    const isCommander2 = isCommanderFormat && card.id === commanderIds?.[1];
+    const isThisCommander = isCommander1 || isCommander2;
+    const partnerInvalid = isCommander2 && partnerValidation?.valid === false;
+    const warnings = getCardWarnings(card, format, commanderIdentity);
+
+    const rowBg = highlightedId === card.id ? "" : getRowTint(card);
+    const expanded = expandedId === card.id;
+    const ownedNumColor = !card.isOwned || card.ownedQty === 0
+      ? "text-content-disabled"
+      : isFullyOwned
+      ? "text-green-400"
+      : "text-content-tertiary";
+
+    return (
+      <React.Fragment key={card.id}>
+        {showGroupSpacer && (
+          <tr aria-hidden>
+            <td colSpan={TOUCH_COLUMN_COUNT} className="p-0 bg-transparent">
+              <div className="h-3" />
+            </td>
+          </tr>
+        )}
+        <tr
+          ref={(el) => {
+            if (el && cardRefs) cardRefs.current.set(card.id, el);
+          }}
+          className={`transition-colors ${expanded ? "" : "border-b border-neutral-800/40"} ${highlightedId === card.id ? "bg-yellow-400/10 outline outline-1 outline-yellow-400/50" : ""}`}
+          style={highlightedId !== card.id ? { backgroundColor: rowBg } : undefined}
+        >
+          {/* Owned ✓ toggle */}
+          <td className="pl-2 pr-1 py-2.5 w-9 align-top">
+            {(() => {
+              const isFull = card.isOwned && card.ownedQty >= card.quantity;
+              let bg: string, border: string, color: string;
+              if (!card.isOwned) {
+                bg = "transparent"; border = "rgba(255,255,255,0.12)"; color = "#737373";
+              } else if (isFull) {
+                bg = "rgba(74,222,128,0.85)"; border = "transparent"; color = "#fff";
+              } else {
+                bg = "rgba(22,101,52,0.85)"; border = "rgba(74,222,128,0.5)"; color = "#fff";
+              }
+              return (
+                <button
+                  onClick={() => onToggleIsOwned(card.id)}
+                  aria-label={card.isOwned ? "Unmark as owned" : "Mark as owned"}
+                  style={{
+                    width: "28px", height: "28px", borderRadius: "50%",
+                    display: "flex", alignItems: "center", justifyContent: "center",
+                    border: `1px solid ${border}`, background: bg, color,
+                    fontSize: "13px", fontWeight: 700, flexShrink: 0,
+                  }}
+                >
+                  ✓
+                </button>
+              );
+            })()}
+          </td>
+
+          {/* Name + meta (crown · name · warning, then mana + type subline) */}
+          <td className="px-1 py-2.5 min-w-0 align-top">
+            <div className="flex items-center gap-1 min-w-0">
+              {/* Crown — always-visible tap on touch (commander format only) */}
+              {isCommanderFormat && (onAddCommander || onRemoveCommander || onReplaceCommander) && (
+                isThisCommander ? (
+                  <button
+                    onClick={() => onRemoveCommander?.(card.id)}
+                    aria-label="Remove commander"
+                    className="shrink-0"
+                  >
+                    <CrownFilled className={`w-4 h-4 ${partnerInvalid ? "text-red-400" : "text-yellow-400"}`} />
+                  </button>
+                ) : (
+                  (() => {
+                    const { crownAction, canAct } = getCrownDecision(card);
+                    return (
+                      <button
+                        onClick={() => canAct && crownAction?.()}
+                        aria-label="Set as commander"
+                        className={`shrink-0 ${canAct ? "" : "opacity-40"}`}
+                      >
+                        <CrownOutline className={`w-4 h-4 ${canAct ? "text-content-faint" : "text-content-faint"}`} />
+                      </button>
+                    );
+                  })()
+                )
+              )}
+
+              {partnerInvalid && (
+                <span title={partnerValidation?.warning} className="shrink-0">
+                  <svg width="14" height="14" viewBox="0 0 24 24">
+                    <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" fill="#f59e0b" stroke="none" />
+                    <path d="M12 9v4" stroke="white" strokeWidth="2.2" strokeLinecap="round" fill="none" />
+                    <circle cx="12" cy="17" r="1" fill="white" />
+                  </svg>
+                </span>
+              )}
+
+              <span
+                onClick={() => onSelect(card)}
+                className={`font-medium truncate ${nameColor}`}
+                style={{ opacity: cellOpacity }}
+              >
+                {card.name}
+              </span>
+
+              {warnings.length > 0 && (
+                <span title={warnings.join("\n")} className="shrink-0">
+                  <svg width="15" height="15" viewBox="0 0 24 24">
+                    <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" fill="#f87171" stroke="none" />
+                    <path d="M12 9v4" stroke="white" strokeWidth="2.2" strokeLinecap="round" fill="none" />
+                    <circle cx="12" cy="17" r="1" fill="white" />
+                  </svg>
+                </span>
+              )}
+            </div>
+            {/* Mana + type subline */}
+            <div className={`flex items-center gap-1.5 mt-0.5 min-w-0 ${cellGrayscale}`} style={{ opacity: cellOpacity }}>
+              {card.card_faces ? (
+                <div className="flex items-center gap-1 shrink-0">
+                  {renderManaSymbols(card.card_faces[0].mana_cost)}
+                  <span className="text-[11px] text-content-faint font-bold">//</span>
+                  {renderManaSymbols(card.card_faces[1].mana_cost)}
+                </div>
+              ) : (
+                <div className="shrink-0">{renderManaSymbols((card as any).mana_cost)}</div>
+              )}
+              <span className="text-[11px] text-content-muted truncate">
+                {card.type_line || "—"}
+              </span>
+            </div>
+          </td>
+
+          {/* Qty chip — tap to expand edit controls */}
+          <td className="px-1 py-2.5 w-14 align-top text-right">
+            <button
+              onClick={() => setExpandedId(expanded ? null : card.id)}
+              aria-label="Edit quantities"
+              className={`inline-flex items-center justify-center min-w-[34px] h-7 px-2 rounded-full text-sm font-bold tabular-nums transition-colors ${
+                expanded
+                  ? "bg-surface-overlay text-content-heading"
+                  : "bg-surface-raised text-content-secondary"
+              } ${overCopyLimit ? "text-red-400" : ""}`}
+            >
+              {card.quantity}
+            </button>
+          </td>
+
+          {/* Price */}
+          <td
+            className={`pr-2 py-2.5 text-right text-[11px] tabular-nums w-14 text-content-tertiary align-top ${cellGrayscale}`}
+            style={{ opacity: cellOpacity }}
+          >
+            {card.prices.usd ? `$${card.prices.usd}` : "N/A"}
+          </td>
+        </tr>
+
+        {/* Expanded edit sub-row — owned toggle · owned stepper · qty stepper · remove */}
+        {expanded && (
+          <tr
+            className="border-b border-neutral-800/40"
+            style={highlightedId !== card.id ? { backgroundColor: rowBg } : undefined}
+          >
+            <td colSpan={TOUCH_COLUMN_COUNT} className="px-2 pb-3 pt-0">
+              <div className="flex items-center gap-1.5 flex-wrap justify-center rounded-lg bg-surface-raised/60 py-2 px-2">
+                {/* Owned toggle */}
+                <button
+                  onClick={() => onToggleIsOwned(card.id)}
+                  aria-label={card.isOwned ? "Unmark as owned" : "Mark as owned"}
+                  className={`w-7 h-7 rounded-full flex items-center justify-center text-sm font-bold border shrink-0 transition-colors ${
+                    card.isOwned
+                      ? isFullyOwned
+                        ? "bg-emerald-500 border-transparent text-white"
+                        : "bg-emerald-700 border-emerald-400/50 text-white"
+                      : "bg-surface-overlay border-line-default text-content-tertiary"
+                  }`}
+                >
+                  ✓
+                </button>
+
+                {/* Owned stepper */}
+                <div className="flex items-center gap-1 shrink-0">
+                  <button
+                    onClick={() => onUpdateOwnedQty(card.id, Math.max(0, card.ownedQty - 1))}
+                    aria-label="Decrease owned"
+                    className="w-7 h-7 rounded-full bg-surface-overlay text-content-tertiary active:bg-surface-base flex items-center justify-center transition-colors"
+                  >
+                    <Minus className="w-3.5 h-3.5" />
+                  </button>
+                  {editingOwnedId === card.id ? (
+                    <input
+                      type="text"
+                      value={ownedEditValue}
+                      onChange={(e) => setOwnedEditValue(e.target.value)}
+                      onFocus={(e) => e.target.select()}
+                      onBlur={() => { if (isOwnedEscaping.current) { isOwnedEscaping.current = false; return; } commitOwnedEdit(card); }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") { e.preventDefault(); commitOwnedEdit(card); }
+                        if (e.key === "Escape") { isOwnedEscaping.current = true; setEditingOwnedId(null); }
+                      }}
+                      className="w-8 text-center text-xs font-bold bg-surface-base border border-blue-500 rounded text-green-400 focus:outline-none"
+                      autoFocus
+                    />
+                  ) : (
+                    <button
+                      onClick={() => startOwnedEdit(card)}
+                      className={`w-8 text-center text-xs font-bold tabular-nums ${ownedNumColor}`}
+                    >
+                      {card.ownedQty}
+                    </button>
+                  )}
+                  <button
+                    onClick={() => onUpdateOwnedQty(card.id, card.ownedQty + 1)}
+                    aria-label="Increase owned"
+                    className="w-7 h-7 rounded-full bg-surface-overlay text-content-tertiary active:bg-surface-base flex items-center justify-center transition-colors"
+                  >
+                    <Plus className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+
+                <span className="text-[11px] text-content-muted select-none">/</span>
+
+                {/* Qty stepper */}
+                <div className="flex items-center gap-1 shrink-0">
+                  <button
+                    onClick={() => onUpdateQuantity(card.id, -1)}
+                    aria-label="Decrease quantity"
+                    className="w-7 h-7 rounded-full bg-surface-overlay text-content-tertiary active:bg-surface-base flex items-center justify-center transition-colors"
+                  >
+                    <Minus className="w-3.5 h-3.5" />
+                  </button>
+                  {editingId === card.id ? (
+                    <input
+                      type="text"
+                      value={editValue}
+                      onChange={(e) => setEditValue(e.target.value)}
+                      onFocus={(e) => e.target.select()}
+                      onBlur={() => { if (isEscaping.current) { isEscaping.current = false; return; } commitEdit(card); }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") { e.preventDefault(); commitEdit(card); }
+                        if (e.key === "Escape") { isEscaping.current = true; setEditingId(null); }
+                      }}
+                      className="w-8 text-center text-sm font-bold bg-surface-base border border-blue-500 rounded text-content-heading focus:outline-none"
+                      autoFocus
+                    />
+                  ) : (
+                    <button
+                      onClick={() => startEdit(card)}
+                      className={`w-8 text-center text-sm font-bold tabular-nums ${overCopyLimit ? "text-red-400" : "text-content-secondary"}`}
+                    >
+                      {card.quantity}
+                    </button>
+                  )}
+                  <button
+                    onClick={() => onUpdateQuantity(card.id, 1)}
+                    aria-label="Increase quantity"
+                    className="w-7 h-7 rounded-full bg-surface-overlay text-content-tertiary active:bg-surface-base flex items-center justify-center transition-colors"
+                  >
+                    <Plus className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+
+                {/* Remove — red, separated to the right */}
+                <button
+                  onClick={() => onRemove(card.id)}
+                  aria-label="Remove card"
+                  className="w-7 h-7 ml-1 rounded-full flex items-center justify-center bg-red-900 text-red-300 active:bg-red-800 transition-colors shrink-0"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+            </td>
+          </tr>
+        )}
+      </React.Fragment>
+    );
+  };
+
   return (
     <div
       className="bg-surface-base border border-line-subtle rounded-lg shadow-sm"
       onMouseMove={onMouseMove}
     >
       <table className="w-full table-fixed text-left text-sm">
-        {showHeader && (
+        {/* Touch uses a fixed colgroup so the compact columns stay stable even
+            when the first body row is a pinned commander or a group spacer. */}
+        {isTouch && (
+          <colgroup>
+            <col className="w-9" />
+            <col />
+            <col className="w-14" />
+            <col className="w-14" />
+          </colgroup>
+        )}
+        {showHeader && !isTouch && (
           <thead className="bg-surface-base text-[11px] text-content-muted border-b border-line-subtle uppercase tracking-wider">
             <tr>
               <th className="px-2 py-1.5 w-10"></th>
@@ -659,16 +1015,20 @@ export default function ListCardTable({
           {/* Pinned commander rows */}
           {pinnedCommanders.length > 0 && (
             <>
-              {pinnedCommanders.map((cmd, i) => renderRow(cmd, i, true))}
+              {pinnedCommanders.map((cmd, i) =>
+                isTouch ? renderTouchRow(cmd, i, true) : renderRow(cmd, i, true),
+              )}
               <tr aria-hidden>
-                <td colSpan={COLUMN_COUNT} className="p-0 bg-transparent">
+                <td colSpan={isTouch ? TOUCH_COLUMN_COUNT : COLUMN_COUNT} className="p-0 bg-transparent">
                   <div className="h-3" />
                 </td>
               </tr>
             </>
           )}
           {/* Remaining cards */}
-          {bodyCards.map((card, index) => renderRow(card, index))}
+          {bodyCards.map((card, index) =>
+            isTouch ? renderTouchRow(card, index) : renderRow(card, index),
+          )}
         </tbody>
       </table>
     </div>

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,10 +1,16 @@
 // Keep in sync with `Current Version` in CLAUDE.md and CHANGELOG.md.
 // Three files change together on every version bump.
-export const APP_VERSION = "1.30.2";
+export const APP_VERSION = "1.31.0";
 
 // Each entry is an array of bullet points — one string per item.
 // New versions should follow this same format.
 export const CHANGELOG: Record<string, string[]> = {
+  "1.31.0": [
+    "Feature: the list view now works on a phone/tablet. The desktop list is a wide 7-column table (a dual owned/quantity stepper, type, mana, price) that ran off the side of a phone and whose controls only appeared on mouse-hover, so on touch it was unusable. On touch each card is now a compact row — owned ✓, name with its mana + type underneath, the quantity, and price — that fits the screen.",
+    "Feature: tap the quantity chip on a row and it expands to reveal the full edit controls — mark-owned toggle, owned and quantity steppers (tap a number to type it), and a red remove button. This mirrors the tap-to-edit bar added to the grid (visual) view.",
+    "Enhancement: in Commander decks the 'set as commander/partner' crown is an always-visible tap on each list row on touch, instead of a hover-only control.",
+    "Chore: desktop list view is unchanged — the full 7-column hover table renders exactly as before. The compact touch layout is driven by the shared (hover: none) check.",
+  ],
   "1.30.2": [
     "Fix: the mobile 'Tools' button no longer has a box around it — dropped the border, background, and shadow so it's a plain icon button matching the rest of the site's chrome (the hamburger menu, sidebar rail, etc.).",
   ],


### PR DESCRIPTION
## List view on mobile

Brings the list (table) view to touch, mirroring the grid-view touch pass (v1.27.0).

### The problem
The list view is a 7-column `table-fixed` (owned ✓ · a `w-52` dual owned/qty stepper · name · type · mana · price · remove) — ~656px of fixed columns that ran off the side of a phone, and whose steppers only appeared on **mouse hover**, so on touch they were unreachable.

### The change (`ListCardTable.tsx`)
On touch (`useIsTouch()` → `(hover: none)`):
- **Compact 4-column row** (`renderTouchRow`): owned ✓ · name (mana symbols + type line as a subline) · **qty chip** · price.
- **Tap-to-expand edit sub-row** — tapping the qty chip opens an inline bar with full parity: owned toggle, owned/qty steppers (tap a number to type it), and a red remove ✕ separated to the right.
- **Fixed `<colgroup>`** pins the touch column widths; desktop `<thead>` is hidden on touch.
- **Commander crown** becomes an always-visible per-row tap via a shared `getCrownDecision()` helper.

**Desktop (`renderRow`) is unchanged** — the full 7-column hover table renders exactly as before. The split is driven entirely by the shared `(hover: none)` check.

### Verification
- `tsc --noEmit` passes.
- Production build only fails on the sandbox being unable to fetch Google Fonts (`layout.tsx` Inter) — unrelated to this change.
- Not yet visually QA'd on a real touch viewport (app won't boot here without the font fetch) — worth a quick look on a phone/iPad before relying on it.

Bumped to **v1.31.0**; updated `version.ts`, `CHANGELOG.md`, `CLAUDE.md`, and documented the pattern in `docs/ARCHITECTURE.md` → Touch & Sizing System.

https://claude.ai/code/session_01NsiVdyJWLdJ9aPojo1KBr4

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsiVdyJWLdJ9aPojo1KBr4)_